### PR TITLE
Introduce param to set CLOSED-CAPTIONS=NONE when there are no closed captions on any variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Updates the option values
 ##### supported options
 | Name       | Type    | Default | Description   |
 | ---------- | ------- | ------- | ------------- |
-| strictMode | boolean | false   | If true, the function throws an error when `parse`/`stringify` failed. If false, the function just logs the error and continues to run.|
+| `strictMode` | boolean | false   | If true, the function throws an error when `parse`/`stringify` failed. If false, the function just logs the error and continues to run.|
+| `allowClosedCaptionsNone` | boolean | false | If true, `CLOSED-CAPTIONS` attribute on the `EXT-X-STREAM-INF` tag will be set to the enumerated-string value NONE when there are no closed-captions. See [CLOSED-CAPTIONS](https://tools.ietf.org/html/rfc8216#section-4.3.4.2) |
 
 ### `HLS.getOptions()`
 Retrieves the current option values
@@ -101,7 +102,6 @@ This section describes the structure of the object returned by `parse()` method.
 | `independentSegments` | boolean | No       | false      | See [EXT-X-INDEPENDENT-SEGMENTS](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.5.1) |
 | `start` | object({offset: number, precise: boolean}) | No       | undefined      | See [EXT-X-START](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.5.2) |
 | `source` | string     | No      | undefined     | The unprocessed text of the playlist  |
-| `allowClosedCaptionsNone` | boolean | No | false | `true` if `CLOSED-CAPTIONS` attribute should be set to the enumerated-string value NONE when there are no closed-captions. See [CLOSED-CAPTIONS](https://tools.ietf.org/html/rfc8216#section-4.3.4.2) |
 
 ### `MasterPlaylist` (extends `Playlist`)
 | Property          | Type     | Required | Default   | Description   |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This section describes the structure of the object returned by `parse()` method.
 | `independentSegments` | boolean | No       | false      | See [EXT-X-INDEPENDENT-SEGMENTS](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.5.1) |
 | `start` | object({offset: number, precise: boolean}) | No       | undefined      | See [EXT-X-START](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.5.2) |
 | `source` | string     | No      | undefined     | The unprocessed text of the playlist  |
+| `allowClosedCaptionsNone` | boolean | No | false | `true` if `CLOSED-CAPTIONS` attribute should be set to the enumerated-string value NONE when there are no closed-captions. See [CLOSED-CAPTIONS](https://tools.ietf.org/html/rfc8216#section-4.3.4.2) |
 
 ### `MasterPlaylist` (extends `Playlist`)
 | Property          | Type     | Required | Default   | Description   |

--- a/stringify.js
+++ b/stringify.js
@@ -57,7 +57,7 @@ function buildMasterPlaylist(lines, playlist) {
     buildKey(lines, sessionKey, true);
   }
   for (const variant of playlist.variants) {
-    buildVariant(lines, variant, playlist);
+    buildVariant(lines, variant);
   }
 }
 
@@ -95,7 +95,7 @@ function buildKey(lines, key, isSessionKey) {
   lines.push(`${name}:${attrs.join(',')}`);
 }
 
-function buildVariant(lines, variant, playlist) {
+function buildVariant(lines, variant) {
   const name = variant.isIFrameOnly ? '#EXT-X-I-FRAME-STREAM-INF' : '#EXT-X-STREAM-INF';
   const attrs = [`BANDWIDTH=${variant.bandwidth}`];
   if (variant.averageBandwidth) {
@@ -134,7 +134,7 @@ function buildVariant(lines, variant, playlist) {
       buildRendition(lines, rendition);
     }
   }
-  if (playlist.allowClosedCaptionsNone && variant.closedCaptions.length === 0) {
+  if (utils.getOptions().allowClosedCaptionsNone && variant.closedCaptions.length === 0) {
     attrs.push(`CLOSED-CAPTIONS=NONE`);
   } else if (variant.closedCaptions.length > 0) {
     attrs.push(`CLOSED-CAPTIONS="${variant.closedCaptions[0].groupId}"`);

--- a/stringify.js
+++ b/stringify.js
@@ -57,7 +57,7 @@ function buildMasterPlaylist(lines, playlist) {
     buildKey(lines, sessionKey, true);
   }
   for (const variant of playlist.variants) {
-    buildVariant(lines, variant);
+    buildVariant(lines, variant, playlist);
   }
 }
 
@@ -95,7 +95,7 @@ function buildKey(lines, key, isSessionKey) {
   lines.push(`${name}:${attrs.join(',')}`);
 }
 
-function buildVariant(lines, variant) {
+function buildVariant(lines, variant, playlist) {
   const name = variant.isIFrameOnly ? '#EXT-X-I-FRAME-STREAM-INF' : '#EXT-X-STREAM-INF';
   const attrs = [`BANDWIDTH=${variant.bandwidth}`];
   if (variant.averageBandwidth) {
@@ -134,7 +134,9 @@ function buildVariant(lines, variant) {
       buildRendition(lines, rendition);
     }
   }
-  if (variant.closedCaptions.length > 0) {
+  if (playlist.allowClosedCaptionsNone && variant.closedCaptions.length === 0) {
+    attrs.push(`CLOSED-CAPTIONS=NONE`);
+  } else if (variant.closedCaptions.length > 0) {
     attrs.push(`CLOSED-CAPTIONS="${variant.closedCaptions[0].groupId}"`);
     for (const rendition of variant.closedCaptions) {
       buildRendition(lines, rendition);

--- a/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.4_Master-Playlist-Tags/4.3.4.2_EXT-X-STREAM-INF.spec.js
+++ b/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.4_Master-Playlist-Tags/4.3.4.2_EXT-X-STREAM-INF.spec.js
@@ -143,6 +143,20 @@ test('#EXT-X-STREAM-INF_07-02', t => {
   `);
 });
 
+test('#EXT-X-STREAM-INF_07-03', t => {
+  const sourceText = `
+  #EXTM3U
+  #EXT-X-STREAM-INF:BANDWIDTH=1280000,CLOSED-CAPTIONS=NONE
+  /video/main.m3u8
+  #EXT-X-STREAM-INF:BANDWIDTH=2040000,CLOSED-CAPTIONS=NONE
+  /video/high.m3u8
+  `;
+  const obj = HLS.parse(sourceText);
+  obj.allowClosedCaptionsNone = true;
+  const text = HLS.stringify(obj);
+  t.is(text, utils.stripCommentsAndEmptyLines(sourceText));
+});
+
 // The URI attribute of the EXT-X-MEDIA tag is REQUIRED if the media
 // type is SUBTITLES
 test('#EXT-X-STREAM-INF_08', t => {

--- a/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.4_Master-Playlist-Tags/4.3.4.2_EXT-X-STREAM-INF.spec.js
+++ b/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.4_Master-Playlist-Tags/4.3.4.2_EXT-X-STREAM-INF.spec.js
@@ -151,8 +151,8 @@ test('#EXT-X-STREAM-INF_07-03', t => {
   #EXT-X-STREAM-INF:BANDWIDTH=2040000,CLOSED-CAPTIONS=NONE
   /video/high.m3u8
   `;
+  HLS.setOptions({allowClosedCaptionsNone: true});
   const obj = HLS.parse(sourceText);
-  obj.allowClosedCaptionsNone = true;
   const text = HLS.stringify(obj);
   t.is(text, utils.stripCommentsAndEmptyLines(sourceText));
 });

--- a/types.js
+++ b/types.js
@@ -170,7 +170,8 @@ class Playlist extends Data {
     version,
     independentSegments = false,
     start,
-    source
+    source,
+    allowClosedCaptionsNone = false
   }) {
     super('playlist');
     utils.PARAMCHECK(isMasterPlaylist);
@@ -180,6 +181,7 @@ class Playlist extends Data {
     this.independentSegments = independentSegments;
     this.start = start;
     this.source = source;
+    this.allowClosedCaptionsNone = allowClosedCaptionsNone;
   }
 }
 

--- a/types.js
+++ b/types.js
@@ -170,8 +170,7 @@ class Playlist extends Data {
     version,
     independentSegments = false,
     start,
-    source,
-    allowClosedCaptionsNone = false
+    source
   }) {
     super('playlist');
     utils.PARAMCHECK(isMasterPlaylist);
@@ -181,7 +180,6 @@ class Playlist extends Data {
     this.independentSegments = independentSegments;
     this.start = start;
     this.source = source;
-    this.allowClosedCaptionsNone = allowClosedCaptionsNone;
   }
 }
 


### PR DESCRIPTION
On iOS Safari, the Video Player unexpectedly shows the `Unknown CC` track in the absence of closed caption content in the playlist. See https://developer.apple.com/library/archive/qa/qa1801/_index.html.

This PR introduces a parameter to allow by default set `CLOSED-CAPTIONS=NONE` when there  are no closed captions on any variants. This approach is taken because `CLOSED-CAPTIONS` is an optional attribute and makes more sense as something to opt into.

Usage:

```js
const playlist = { ... };
playlist.allowClosedCaptionsNone = true;
const text = HLS.stringify(playlist);
```