### PR TITLE
Add double quotes to BYTERANGE in EXT-X-MAP

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -238,7 +238,7 @@ function buildSegment(lines, segment, version = 1) {
 function buildMap(lines, map) {
   const attrs = [`URI="${map.uri}"`];
   if (map.byterange) {
-    attrs.push(`BYTERANGE=${buildByteRange(map.byterange)}`);
+    attrs.push(`BYTERANGE="${buildByteRange(map.byterange)}"`);
   }
   lines.push(`#EXT-X-MAP:${attrs.join(',')}`);
 }


### PR DESCRIPTION
Fixes playback failures in recent iOS and Safari versions.