### PR TITLE
Correctly place ad cue in after final ad slate segment

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -303,6 +303,9 @@ function buildSegment(lines, segment, lastKey, lastMap, version = 1) {
   const duration = version < 3 ? Math.round(segment.duration) : buildDecimalFloatingNumber(segment.duration, getNumberOfDecimalPlaces(segment.duration));
   lines.push(`#EXTINF:${duration},${unescape(encodeURIComponent(segment.title || ''))}`);
   Array.prototype.push.call(lines, `${segment.uri}`); // URIs could be redundant when EXT-X-BYTERANGE is used
+  if (segment.cueIn) {
+    lines.push(`#EXT-X-CUE-IN`)
+  }
   return [lastKey, lastMap];
 }
 


### PR DESCRIPTION
Little helper on the stringify side so if cueIn flag is set on a segment, it will properly place the text after the TS file