### PR TITLE
Allow trailing media segment tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,32 @@ Only `EXT-X-CUE-OUT` and `EXT-X-CUE-IN` tags are supported. Other SCTE-35-relate
 | `tagName`        | string   | No       | undefined        | Holds the tag name if any unsupported tag are found. Required if the `type` is 'RAW' |
 | `value`        | string   | No       | undefined        | Holds a raw (string) value for the unsupported tag. |
 
+If you want to add a trailing `EXT-X-CUE-IN` (e.g. in case the playlist ends with ads segments,) just create an empty segment:
+```js
+const empty = new Segment();
+empty.markers.push({type: 'IN'});
+
+const playlist = new MediaPlaylist({
+  targetDuration: 10,
+  segments: [...ads, empty]
+});
+
+HLS.stringify(playlist);
+/*
+#EXTM3U
+#EXT-X-TARGETDURATION:10
+#EXT-X-DISCONTINUITY
+#EXT-X-CUE-OUT:30
+#EXTINF:10,
+https://example.com/0.ts
+#EXTINF:10,
+https://example.com/1.ts
+#EXTINF:10,
+https://example.com/2.ts
+#EXT-X-CUE-IN
+*/
+```
+
 ### `RenditionReport`
 | Property          | Type     | Required | Default   | Description   |
 | ----------------- | -------- | -------- | --------- | ------------- |

--- a/stringify.js
+++ b/stringify.js
@@ -301,8 +301,12 @@ function buildSegment(lines, segment, lastKey, lastMap, version = 1) {
     return [lastKey, lastMap];
   }
   const duration = version < 3 ? Math.round(segment.duration) : buildDecimalFloatingNumber(segment.duration, getNumberOfDecimalPlaces(segment.duration));
-  lines.push(`#EXTINF:${duration},${unescape(encodeURIComponent(segment.title || ''))}`);
-  Array.prototype.push.call(lines, `${segment.uri}`); // URIs could be redundant when EXT-X-BYTERANGE is used
+  if (duration > 0) {
+    lines.push(`#EXTINF:${duration},${unescape(encodeURIComponent(segment.title || ''))}`);
+  }
+  if (segment.uri) {
+    Array.prototype.push.call(lines, `${segment.uri}`); // URIs could be redundant when EXT-X-BYTERANGE is used
+  }
   return [lastKey, lastMap];
 }
 

--- a/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.3.2.1_EXTINF.spec.js
+++ b/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.3.2.1_EXTINF.spec.js
@@ -1,4 +1,5 @@
 const test = require('ava');
+const HLS = require('../../../../..');
 const utils = require('../../../../helpers/utils');
 
 // This tag is REQUIRED for each Media Segment
@@ -55,4 +56,18 @@ test('#EXTINF_03', t => {
     #EXTINF:10,${unescape(encodeURIComponent('\u3042'))}
     http://example.com/1
   `);
+});
+
+// Skip if duration is zero
+test('#EXTINF_04', t => {
+  const {MediaPlaylist, Segment} = HLS.types;
+  const playlist = new MediaPlaylist({
+    targetDuration: 10,
+    segments: [new Segment()]
+  });
+  const expected = `
+    #EXTM3U
+    #EXT-X-TARGETDURATION:10
+  `;
+  t.is(HLS.stringify(playlist), utils.stripCommentsAndEmptyLines(expected));
 });

--- a/test/spec/SCTE-35/01_EXT-X-CUE-IN.spec.js
+++ b/test/spec/SCTE-35/01_EXT-X-CUE-IN.spec.js
@@ -1,0 +1,36 @@
+const test = require('ava');
+const HLS = require('../../..');
+const utils = require('../../helpers/utils');
+
+// Allow indipendent EXT-X-CUE-IN
+test('#EXT-X-CUE-IN_01', t => {
+  const {MediaPlaylist, Segment} = HLS.types;
+
+  const ads = [...new Array(3)].map((_, i) => new Segment({uri: `https://example.com/${i}.ts`, duration: 10}));
+  ads[0].discontinuity = true;
+  ads[0].markers.push({type: 'OUT', duration: 30});
+
+  const empty = new Segment();
+  empty.markers.push({type: 'IN'});
+
+  const playlist = new MediaPlaylist({
+    targetDuration: 10,
+    segments: [...ads, empty]
+  });
+
+  const expected = `
+    #EXTM3U
+    #EXT-X-TARGETDURATION:10
+    #EXT-X-DISCONTINUITY
+    #EXT-X-CUE-OUT:30
+    #EXTINF:10,
+    https://example.com/0.ts
+    #EXTINF:10,
+    https://example.com/1.ts
+    #EXTINF:10,
+    https://example.com/2.ts
+    #EXT-X-CUE-IN
+  `;
+
+  t.is(HLS.stringify(playlist), utils.stripCommentsAndEmptyLines(expected));
+});

--- a/types.js
+++ b/types.js
@@ -254,7 +254,7 @@ class Segment extends Data {
     dateRange,
     markers = [],
     parts = []
-  }) {
+  } = {}) {
     super('segment');
     // utils.PARAMCHECK(uri, mediaSequenceNumber, discontinuitySequence);
     this.uri = uri;


### PR DESCRIPTION
According to https://github.com/kuu/hls-parser/pull/88, there's a situation where an independent #EXT-X-CUE-IN tag is required at the end of a media playlist (e.g. the playlist ends with ads segments.)

This PR enables an empty segment to be added to the playlist so any trailing tags can be possible:

```js
const empty = new Segment();
empty.markers.push({type: 'IN'});

const playlist = new MediaPlaylist({
  targetDuration: 10,
  segments: [...ads, empty]
});

HLS.stringify(playlist);
/*
#EXTM3U
#EXT-X-TARGETDURATION:10
#EXT-X-DISCONTINUITY
#EXT-X-CUE-OUT:30
#EXTINF:10,
https://example.com/0.ts
#EXTINF:10,
https://example.com/1.ts
#EXTINF:10,
https://example.com/2.ts
#EXT-X-CUE-IN
*/
// Trailing EXT-X-CUE-IN
```