### PR TITLE
Safely copy lines to avoid memory leaks

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -939,7 +939,10 @@ function parseTag(line, params) {
 function lexicalParse(text, params) {
   const lines = [];
   for (const l of text.split('\n')) {
-    const line = l.trim();
+    // V8 has garbage collection issues when cleaning up substrings split from strings greater
+    // than 13 characters so before we continue we need to safely copy over each line so that it
+    // doesn't hold any reference to the containing string.
+    const line = Buffer.from(l.trim()).toString();
     if (!line) {
       // empty line
       continue;


### PR DESCRIPTION
V8 has garbage collection issues when cleaning up substrings split from strings greater
than 13 characters, so before the lexical parsing we need to safely copy over each line
so that it doesn't hold any reference to the original containing string.

Node Issue for reference: https://bugs.chromium.org/p/v8/issues/detail?id=2869