### PR TITLE
Reduce the number of linting warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ module.exports = {
   stringify,
   types,
   getOptions,
-  setOptions
+  setOptions,
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "esnext": true,
     "space": true,
     "rules": {
-      "arrow-body-style": 0,
       "ava/no-ignored-test-files": 0,
       "camelcase": 0,
       "comma-dangle": 0,

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
       "no-multi-assign": 0,
       "n/prefer-global/buffer": 1,
       "padding-line-between-statements": 0,
-      "quotes": 0,
       "unicorn/catch-error-name": 0,
       "unicorn/filename-case": 0,
       "unicorn/no-lonely-if": 0,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "rules": {
       "camelcase": 0,
       "capitalized-comments": 0,
-      "dot-notation": 0,
       "import/extensions": 0,
       "import/no-dynamic-require": 0,
       "new-cap": 0,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "space": true,
     "rules": {
       "camelcase": 0,
-      "comma-dangle": 0,
       "capitalized-comments": 0,
       "dot-notation": 0,
       "import/extensions": 0,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "esnext": true,
     "space": true,
     "rules": {
-      "ava/no-ignored-test-files": 0,
       "camelcase": 0,
       "comma-dangle": 0,
       "capitalized-comments": 0,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
       "import/extensions": 0,
       "import/no-dynamic-require": 0,
       "new-cap": 0,
-      "node/prefer-global/buffer": 0,
       "no-bitwise": 0,
       "no-cond-assign": 0,
       "no-mixed-operators": 0,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
       "no-cond-assign": 0,
       "no-mixed-operators": 0,
       "no-multi-assign": 0,
-      "operator-linebreak": 0,
       "n/prefer-global/buffer": 0,
       "padding-line-between-statements": 0,
       "quotes": 0,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
       "unicorn/filename-case": 0,
       "unicorn/no-lonely-if": 0,
       "unicorn/no-zero-fractions": 0,
-      "unicorn/numeric-separators-style": 0,
       "unicorn/prefer-code-point": 0,
       "unicorn/prefer-module": 0,
       "unicorn/prefer-switch": 0,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "no-cond-assign": 0,
       "no-mixed-operators": 0,
       "no-multi-assign": 0,
-      "n/prefer-global/buffer": 0,
+      "n/prefer-global/buffer": 1,
       "padding-line-between-statements": 0,
       "quotes": 0,
       "unicorn/catch-error-name": 0,

--- a/parse.js
+++ b/parse.js
@@ -249,7 +249,7 @@ function parseTagParam(name, param) {
 }
 
 function MIXEDTAGS() {
-  utils.INVALIDPLAYLIST(`The file contains both media and master playlist tags.`);
+  utils.INVALIDPLAYLIST('The file contains both media and master playlist tags.');
 }
 
 function splitTag(line) {

--- a/parse.js
+++ b/parse.js
@@ -120,10 +120,10 @@ function parseUserAttribute(str) {
 }
 
 function setCompatibleVersionOfKey(params, attributes) {
-  if (attributes['IV'] && params.compatibleVersion < 2) {
+  if (attributes.IV && params.compatibleVersion < 2) {
     params.compatibleVersion = 2;
   }
-  if ((attributes['KEYFORMAT'] || attributes['KEYFORMATVERSIONS']) && params.compatibleVersion < 5) {
+  if ((attributes.KEYFORMAT || attributes.KEYFORMATVERSIONS) && params.compatibleVersion < 5) {
     params.compatibleVersion = 5;
   }
 }
@@ -262,18 +262,18 @@ function splitTag(line) {
 
 function parseRendition({attributes}) {
   const rendition = new Rendition({
-    type: attributes['TYPE'],
-    uri: attributes['URI'],
+    type: attributes.TYPE,
+    uri: attributes.URI,
     groupId: attributes['GROUP-ID'],
-    language: attributes['LANGUAGE'],
+    language: attributes.LANGUAGE,
     assocLanguage: attributes['ASSOC-LANGUAGE'],
-    name: attributes['NAME'],
-    isDefault: attributes['DEFAULT'],
-    autoselect: attributes['AUTOSELECT'],
-    forced: attributes['FORCED'],
+    name: attributes.NAME,
+    isDefault: attributes.DEFAULT,
+    autoselect: attributes.AUTOSELECT,
+    forced: attributes.FORCED,
     instreamId: attributes['INSTREAM-ID'],
-    characteristics: attributes['CHARACTERISTICS'],
-    channels: attributes['CHANNELS'],
+    characteristics: attributes.CHARACTERISTICS,
+    channels: attributes.CHANNELS,
   });
   return rendition;
 }
@@ -321,11 +321,11 @@ function matchTypes(attrs, variant, params) {
 function parseVariant(lines, variantAttrs, uri, iFrameOnly, params) {
   const variant = new Variant({
     uri,
-    bandwidth: variantAttrs['BANDWIDTH'],
+    bandwidth: variantAttrs.BANDWIDTH,
     averageBandwidth: variantAttrs['AVERAGE-BANDWIDTH'],
-    score: variantAttrs['SCORE'],
-    codecs: variantAttrs['CODECS'],
-    resolution: variantAttrs['RESOLUTION'],
+    score: variantAttrs.SCORE,
+    codecs: variantAttrs.CODECS,
+    resolution: variantAttrs.RESOLUTION,
     frameRate: variantAttrs['FRAME-RATE'],
     hdcpLevel: variantAttrs['HDCP-LEVEL'],
     allowedCpc: variantAttrs['ALLOWED-CPC'],
@@ -335,7 +335,7 @@ function parseVariant(lines, variantAttrs, uri, iFrameOnly, params) {
   for (const line of lines) {
     if (line.name === 'EXT-X-MEDIA') {
       const renditionAttrs = line.attributes;
-      const renditionType = renditionAttrs['TYPE'];
+      const renditionType = renditionAttrs.TYPE;
       if (!renditionType || !renditionAttrs['GROUP-ID']) {
         utils.INVALIDPLAYLIST('EXT-X-MEDIA TYPE attribute is REQUIRED.');
       }
@@ -417,24 +417,24 @@ function parseMasterPlaylist(lines, params) {
     } else if (name === 'EXT-X-SESSION-DATA') {
       const sessionData = new SessionData({
         id: attributes['DATA-ID'],
-        value: attributes['VALUE'],
-        uri: attributes['URI'],
-        language: attributes['LANGUAGE'],
+        value: attributes.VALUE,
+        uri: attributes.URI,
+        language: attributes.LANGUAGE,
       });
       if (playlist.sessionDataList.some(item => item.id === sessionData.id && item.language === sessionData.language)) {
         utils.INVALIDPLAYLIST('A Playlist MUST NOT contain more than one EXT-X-SESSION-DATA tag with the same DATA-ID attribute and the same LANGUAGE attribute.');
       }
       playlist.sessionDataList.push(sessionData);
     } else if (name === 'EXT-X-SESSION-KEY') {
-      if (attributes['METHOD'] === 'NONE') {
+      if (attributes.METHOD === 'NONE') {
         utils.INVALIDPLAYLIST('EXT-X-SESSION-KEY: The value of the METHOD attribute MUST NOT be NONE');
       }
       const sessionKey = new Key({
-        method: attributes['METHOD'],
-        uri: attributes['URI'],
-        iv: attributes['IV'],
-        format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS'],
+        method: attributes.METHOD,
+        uri: attributes.URI,
+        iv: attributes.IV,
+        format: attributes.KEYFORMAT,
+        formatVersion: attributes.KEYFORMATVERSIONS,
       });
       if (playlist.sessionKeyList.some(item => sameKey(item, sessionKey))) {
         utils.INVALIDPLAYLIST('A Master Playlist MUST NOT contain more than one EXT-X-SESSION-KEY tag with the same METHOD, URI, IV, KEYFORMAT, and KEYFORMATVERSIONS attribute values.');
@@ -453,7 +453,7 @@ function parseMasterPlaylist(lines, params) {
       if (typeof attributes['TIME-OFFSET'] !== 'number') {
         utils.INVALIDPLAYLIST('EXT-X-START: TIME-OFFSET attribute is REQUIRED');
       }
-      playlist.start = {offset: attributes['TIME-OFFSET'], precise: attributes['PRECISE'] || false};
+      playlist.start = {offset: attributes['TIME-OFFSET'], precise: attributes.PRECISE || false};
     }
   }
   if (variantIsScored) {
@@ -504,11 +504,11 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       }
       setCompatibleVersionOfKey(params, attributes);
       segment.key = new Key({
-        method: attributes['METHOD'],
-        uri: attributes['URI'],
-        iv: attributes['IV'],
-        format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS'],
+        method: attributes.METHOD,
+        uri: attributes.URI,
+        iv: attributes.IV,
+        format: attributes.KEYFORMAT,
+        formatVersion: attributes.KEYFORMATVERSIONS,
       });
     } else if (name === 'EXT-X-MAP') {
       if (segment.parts.length > 0) {
@@ -519,8 +519,8 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       }
       params.hasMap = true;
       segment.map = new MediaInitializationSection({
-        uri: attributes['URI'],
-        byterange: attributes['BYTERANGE'],
+        uri: attributes.URI,
+        byterange: attributes.BYTERANGE,
       });
     } else if (name === 'EXT-X-PROGRAM-DATE-TIME') {
       segment.programDateTime = value;
@@ -532,11 +532,11 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
         }
       }
       segment.dateRange = new DateRange({
-        id: attributes['ID'],
-        classId: attributes['CLASS'],
+        id: attributes.ID,
+        classId: attributes.CLASS,
         start: attributes['START-DATE'],
         end: attributes['END-DATE'],
-        duration: attributes['DURATION'],
+        duration: attributes.DURATION,
         plannedDuration: attributes['PLANNED-DURATION'],
         endOnNext: attributes['END-ON-NEXT'],
         attributes: attrs,
@@ -562,13 +562,13 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
         tagName: name,
         value,
       }));
-    } else if (name === 'EXT-X-PRELOAD-HINT' && !attributes['TYPE']) {
+    } else if (name === 'EXT-X-PRELOAD-HINT' && !attributes.TYPE) {
       utils.INVALIDPLAYLIST('EXT-X-PRELOAD-HINT: TYPE attribute is mandatory');
-    } else if (name === 'EXT-X-PRELOAD-HINT' && attributes['TYPE'] === 'PART' && partHint) {
+    } else if (name === 'EXT-X-PRELOAD-HINT' && attributes.TYPE === 'PART' && partHint) {
       utils.INVALIDPLAYLIST('Servers should not add more than one EXT-X-PRELOAD-HINT tag with the same TYPE attribute to a Playlist.');
-    } else if ((name === 'EXT-X-PART' || name === 'EXT-X-PRELOAD-HINT') && !attributes['URI']) {
+    } else if ((name === 'EXT-X-PART' || name === 'EXT-X-PRELOAD-HINT') && !attributes.URI) {
       utils.INVALIDPLAYLIST('EXT-X-PART / EXT-X-PRELOAD-HINT: URI attribute is mandatory');
-    } else if (name === 'EXT-X-PRELOAD-HINT' && attributes['TYPE'] === 'MAP') {
+    } else if (name === 'EXT-X-PRELOAD-HINT' && attributes.TYPE === 'MAP') {
       if (mapHint) {
         utils.INVALIDPLAYLIST('Servers should not add more than one EXT-X-PRELOAD-HINT tag with the same TYPE attribute to a Playlist.');
       }
@@ -576,11 +576,11 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       params.hasMap = true;
       segment.map = new MediaInitializationSection({
         hint: true,
-        uri: attributes['URI'],
+        uri: attributes.URI,
         byterange: {length: attributes['BYTERANGE-LENGTH'], offset: attributes['BYTERANGE-START'] || 0},
       });
-    } else if (name === 'EXT-X-PART' || (name === 'EXT-X-PRELOAD-HINT' && attributes['TYPE'] === 'PART')) {
-      if (name === 'EXT-X-PART' && !attributes['DURATION']) {
+    } else if (name === 'EXT-X-PART' || (name === 'EXT-X-PRELOAD-HINT' && attributes.TYPE === 'PART')) {
+      if (name === 'EXT-X-PART' && !attributes.DURATION) {
         utils.INVALIDPLAYLIST('EXT-X-PART: DURATION attribute is mandatory');
       }
       if (name === 'EXT-X-PRELOAD-HINT') {
@@ -588,11 +588,11 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       }
       const partialSegment = new PartialSegment({
         hint: (name === 'EXT-X-PRELOAD-HINT'),
-        uri: attributes['URI'],
-        byterange: (name === 'EXT-X-PART' ? attributes['BYTERANGE'] : {length: attributes['BYTERANGE-LENGTH'], offset: attributes['BYTERANGE-START'] || 0}),
-        duration: attributes['DURATION'],
-        independent: attributes['INDEPENDENT'],
-        gap: attributes['GAP'],
+        uri: attributes.URI,
+        byterange: (name === 'EXT-X-PART' ? attributes.BYTERANGE : {length: attributes['BYTERANGE-LENGTH'], offset: attributes['BYTERANGE-START'] || 0}),
+        duration: attributes.DURATION,
+        independent: attributes.INDEPENDENT,
+        gap: attributes.GAP,
       });
       segment.parts.push(partialSegment);
     }
@@ -613,11 +613,11 @@ function parsePrefetchSegment(lines, uri, start, end, mediaSequenceNumber, disco
     } else if (name === 'EXT-X-KEY') {
       setCompatibleVersionOfKey(params, attributes);
       segment.key = new Key({
-        method: attributes['METHOD'],
-        uri: attributes['URI'],
-        iv: attributes['IV'],
-        format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS'],
+        method: attributes.METHOD,
+        uri: attributes.URI,
+        iv: attributes.IV,
+        format: attributes.KEYFORMAT,
+        formatVersion: attributes.KEYFORMATVERSIONS,
       });
     } else if (name === 'EXT-X-MAP') {
       utils.INVALIDPLAYLIST('Prefetch segments must not be advertised with an EXT-X-MAP tag.');
@@ -689,7 +689,7 @@ function parseMediaPlaylist(lines, params) {
       if (typeof attributes['TIME-OFFSET'] !== 'number') {
         utils.INVALIDPLAYLIST('EXT-X-START: TIME-OFFSET attribute is REQUIRED');
       }
-      playlist.start = {offset: attributes['TIME-OFFSET'], precise: attributes['PRECISE'] || false};
+      playlist.start = {offset: attributes['TIME-OFFSET'], precise: attributes.PRECISE || false};
     } else if (name === 'EXT-X-SERVER-CONTROL') {
       if (!attributes['CAN-BLOCK-RELOAD']) {
         utils.INVALIDPLAYLIST('EXT-X-SERVER-CONTROL: CAN-BLOCK-RELOAD=YES is mandatory for Low-Latency HLS');
@@ -706,14 +706,14 @@ function parseMediaPlaylist(lines, params) {
       }
       playlist.partTargetDuration = attributes['PART-TARGET'];
     } else if (name === 'EXT-X-RENDITION-REPORT') {
-      if (!attributes['URI']) {
+      if (!attributes.URI) {
         utils.INVALIDPLAYLIST('EXT-X-RENDITION-REPORT: URI attribute is mandatory');
       }
-      if (attributes['URI'].search(/^[a-z]+:/) === 0) {
+      if (attributes.URI.search(/^[a-z]+:/) === 0) {
         utils.INVALIDPLAYLIST('EXT-X-RENDITION-REPORT: URI must be relative to the playlist uri');
       }
       playlist.renditionReports.push(new RenditionReport({
-        uri: attributes['URI'],
+        uri: attributes.URI,
         lastMSN: attributes['LAST-MSN'],
         lastPart: attributes['LAST-PART'],
       }));

--- a/parse.js
+++ b/parse.js
@@ -12,7 +12,7 @@ const {
   Segment,
   PartialSegment,
   PrefetchSegment,
-  RenditionReport
+  RenditionReport,
 } = require('./types');
 
 function unquote(str) {
@@ -273,7 +273,7 @@ function parseRendition({attributes}) {
     forced: attributes['FORCED'],
     instreamId: attributes['INSTREAM-ID'],
     characteristics: attributes['CHARACTERISTICS'],
-    channels: attributes['CHANNELS']
+    channels: attributes['CHANNELS'],
   });
   return rendition;
 }
@@ -330,7 +330,7 @@ function parseVariant(lines, variantAttrs, uri, iFrameOnly, params) {
     hdcpLevel: variantAttrs['HDCP-LEVEL'],
     allowedCpc: variantAttrs['ALLOWED-CPC'],
     videoRange: variantAttrs['VIDEO-RANGE'],
-    stableVariantId: variantAttrs['STABLE-VARIANT-ID']
+    stableVariantId: variantAttrs['STABLE-VARIANT-ID'],
   });
   for (const line of lines) {
     if (line.name === 'EXT-X-MEDIA') {
@@ -419,7 +419,7 @@ function parseMasterPlaylist(lines, params) {
         id: attributes['DATA-ID'],
         value: attributes['VALUE'],
         uri: attributes['URI'],
-        language: attributes['LANGUAGE']
+        language: attributes['LANGUAGE'],
       });
       if (playlist.sessionDataList.some(item => item.id === sessionData.id && item.language === sessionData.language)) {
         utils.INVALIDPLAYLIST('A Playlist MUST NOT contain more than one EXT-X-SESSION-DATA tag with the same DATA-ID attribute and the same LANGUAGE attribute.');
@@ -434,7 +434,7 @@ function parseMasterPlaylist(lines, params) {
         uri: attributes['URI'],
         iv: attributes['IV'],
         format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS']
+        formatVersion: attributes['KEYFORMATVERSIONS'],
       });
       if (playlist.sessionKeyList.some(item => sameKey(item, sessionKey))) {
         utils.INVALIDPLAYLIST('A Master Playlist MUST NOT contain more than one EXT-X-SESSION-KEY tag with the same METHOD, URI, IV, KEYFORMAT, and KEYFORMATVERSIONS attribute values.');
@@ -508,7 +508,7 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
         uri: attributes['URI'],
         iv: attributes['IV'],
         format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS']
+        formatVersion: attributes['KEYFORMATVERSIONS'],
       });
     } else if (name === 'EXT-X-MAP') {
       if (segment.parts.length > 0) {
@@ -520,7 +520,7 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       params.hasMap = true;
       segment.map = new MediaInitializationSection({
         uri: attributes['URI'],
-        byterange: attributes['BYTERANGE']
+        byterange: attributes['BYTERANGE'],
       });
     } else if (name === 'EXT-X-PROGRAM-DATE-TIME') {
       segment.programDateTime = value;
@@ -539,16 +539,16 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
         duration: attributes['DURATION'],
         plannedDuration: attributes['PLANNED-DURATION'],
         endOnNext: attributes['END-ON-NEXT'],
-        attributes: attrs
+        attributes: attrs,
       });
     } else if (name === 'EXT-X-CUE-OUT') {
       segment.markers.push(new SpliceInfo({
         type: 'OUT',
-        duration: (attributes && attributes.DURATION) || value
+        duration: (attributes && attributes.DURATION) || value,
       }));
     } else if (name === 'EXT-X-CUE-IN') {
       segment.markers.push(new SpliceInfo({
-        type: 'IN'
+        type: 'IN',
       }));
     } else if (
       name === 'EXT-X-CUE-OUT-CONT' ||
@@ -560,7 +560,7 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       segment.markers.push(new SpliceInfo({
         type: 'RAW',
         tagName: name,
-        value
+        value,
       }));
     } else if (name === 'EXT-X-PRELOAD-HINT' && !attributes['TYPE']) {
       utils.INVALIDPLAYLIST('EXT-X-PRELOAD-HINT: TYPE attribute is mandatory');
@@ -577,7 +577,7 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
       segment.map = new MediaInitializationSection({
         hint: true,
         uri: attributes['URI'],
-        byterange: {length: attributes['BYTERANGE-LENGTH'], offset: attributes['BYTERANGE-START'] || 0}
+        byterange: {length: attributes['BYTERANGE-LENGTH'], offset: attributes['BYTERANGE-START'] || 0},
       });
     } else if (name === 'EXT-X-PART' || (name === 'EXT-X-PRELOAD-HINT' && attributes['TYPE'] === 'PART')) {
       if (name === 'EXT-X-PART' && !attributes['DURATION']) {
@@ -592,7 +592,7 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
         byterange: (name === 'EXT-X-PART' ? attributes['BYTERANGE'] : {length: attributes['BYTERANGE-LENGTH'], offset: attributes['BYTERANGE-START'] || 0}),
         duration: attributes['DURATION'],
         independent: attributes['INDEPENDENT'],
-        gap: attributes['GAP']
+        gap: attributes['GAP'],
       });
       segment.parts.push(partialSegment);
     }
@@ -617,7 +617,7 @@ function parsePrefetchSegment(lines, uri, start, end, mediaSequenceNumber, disco
         uri: attributes['URI'],
         iv: attributes['IV'],
         format: attributes['KEYFORMAT'],
-        formatVersion: attributes['KEYFORMATVERSIONS']
+        formatVersion: attributes['KEYFORMATVERSIONS'],
       });
     } else if (name === 'EXT-X-MAP') {
       utils.INVALIDPLAYLIST('Prefetch segments must not be advertised with an EXT-X-MAP tag.');
@@ -698,7 +698,7 @@ function parseMediaPlaylist(lines, params) {
         canBlockReload: attributes['CAN-BLOCK-RELOAD'],
         canSkipUntil: attributes['CAN-SKIP-UNTIL'],
         holdBack: attributes['HOLD-BACK'],
-        partHoldBack: attributes['PART-HOLD-BACK']
+        partHoldBack: attributes['PART-HOLD-BACK'],
       };
     } else if (name === 'EXT-X-PART-INF') {
       if (!attributes['PART-TARGET']) {
@@ -715,7 +715,7 @@ function parseMediaPlaylist(lines, params) {
       playlist.renditionReports.push(new RenditionReport({
         uri: attributes['URI'],
         lastMSN: attributes['LAST-MSN'],
-        lastPart: attributes['LAST-PART']
+        lastPart: attributes['LAST-PART'],
       }));
     } else if (name === 'EXT-X-SKIP') {
       if (!attributes['SKIPPED-SEGMENTS']) {
@@ -1000,7 +1000,7 @@ function parse(text) {
     targetDuration: 0,
     compatibleVersion: 1,
     isClosedCaptionsNone: false,
-    hash: {}
+    hash: {},
   };
 
   const lines = lexicalParse(text, params);

--- a/parse.js
+++ b/parse.js
@@ -551,11 +551,11 @@ function parseSegment(lines, uri, start, end, mediaSequenceNumber, discontinuity
         type: 'IN',
       }));
     } else if (
-      name === 'EXT-X-CUE-OUT-CONT' ||
-      name === 'EXT-X-CUE' ||
-      name === 'EXT-OATCLS-SCTE35' ||
-      name === 'EXT-X-ASSET' ||
-      name === 'EXT-X-SCTE35'
+      name === 'EXT-X-CUE-OUT-CONT'
+      || name === 'EXT-X-CUE'
+      || name === 'EXT-OATCLS-SCTE35'
+      || name === 'EXT-X-ASSET'
+      || name === 'EXT-X-SCTE35'
     ) {
       segment.markers.push(new SpliceInfo({
         type: 'RAW',

--- a/stringify.js
+++ b/stringify.js
@@ -8,11 +8,11 @@ const ALLOW_REDUNDANCY = [
   '#EXT-X-CUE-OUT',
   '#EXT-X-CUE-IN',
   '#EXT-X-KEY',
-  '#EXT-X-MAP'
+  '#EXT-X-MAP',
 ];
 
 const SKIP_IF_REDUNDANT = [
-  '#EXT-X-MEDIA'
+  '#EXT-X-MEDIA',
 ];
 
 class LineArray extends Array {
@@ -181,7 +181,7 @@ function buildRendition(rendition) {
   const attrs = [
     `TYPE=${rendition.type}`,
     `GROUP-ID="${rendition.groupId}"`,
-    `NAME="${rendition.name}"`
+    `NAME="${rendition.name}"`,
   ];
   if (rendition.isDefault !== undefined) {
     attrs.push(`DEFAULT=${rendition.isDefault ? 'YES' : 'NO'}`);
@@ -347,7 +347,7 @@ function buildByteRange({offset, length}) {
 
 function buildDateRange(dateRange) {
   const attrs = [
-    `ID="${dateRange.id}"`
+    `ID="${dateRange.id}"`,
   ];
   if (dateRange.start) {
     attrs.push(`START-DATE="${utils.formatDate(dateRange.start)}"`);

--- a/stringify.js
+++ b/stringify.js
@@ -148,7 +148,7 @@ function buildVariant(lines, variant) {
     }
   }
   if (utils.getOptions().allowClosedCaptionsNone && variant.closedCaptions.length === 0) {
-    attrs.push(`CLOSED-CAPTIONS=NONE`);
+    attrs.push('CLOSED-CAPTIONS=NONE');
   } else if (variant.closedCaptions.length > 0) {
     attrs.push(`CLOSED-CAPTIONS="${variant.closedCaptions[0].groupId}"`);
     for (const rendition of variant.closedCaptions) {
@@ -249,7 +249,7 @@ function buildMediaPlaylist(lines, playlist) {
     lines.push(`#EXT-X-PLAYLIST-TYPE:${playlist.playlistType}`);
   }
   if (playlist.isIFrame) {
-    lines.push(`#EXT-X-I-FRAMES-ONLY`);
+    lines.push('#EXT-X-I-FRAMES-ONLY');
   }
   if (playlist.skip > 0) {
     lines.push(`#EXT-X-SKIP:SKIPPED-SEGMENTS=${playlist.skip}`);
@@ -271,12 +271,12 @@ function buildMediaPlaylist(lines, playlist) {
   }
   for (const segment of playlist.prefetchSegments) {
     if (segment.discontinuity) {
-      lines.push(`#EXT-X-PREFETCH-DISCONTINUITY`);
+      lines.push('#EXT-X-PREFETCH-DISCONTINUITY');
     }
     lines.push(`#EXT-X-PREFETCH:${segment.uri}`);
   }
   if (playlist.endlist) {
-    lines.push(`#EXT-X-ENDLIST`);
+    lines.push('#EXT-X-ENDLIST');
   }
   for (const report of playlist.renditionReports) {
     const params = [];
@@ -293,7 +293,7 @@ function buildSegment(lines, segment, lastKey, lastMap, version = 1) {
   let markerType = '';
 
   if (segment.discontinuity) {
-    lines.push(`#EXT-X-DISCONTINUITY`);
+    lines.push('#EXT-X-DISCONTINUITY');
   }
   if (segment.key) {
     const line = buildKey(segment.key);
@@ -365,7 +365,7 @@ function buildDateRange(dateRange) {
     attrs.push(`CLASS="${dateRange.classId}"`);
   }
   if (dateRange.endOnNext) {
-    attrs.push(`END-ON-NEXT=YES`);
+    attrs.push('END-ON-NEXT=YES');
   }
   for (const key of Object.keys(dateRange.attributes)) {
     if (key.startsWith('X-')) {

--- a/test/fixtures/objects/8.1-Simple-Media-Playlist.js
+++ b/test/fixtures/objects/8.1-Simple-Media-Playlist.js
@@ -4,7 +4,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 10,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -14,21 +14,21 @@ function createSegments() {
     duration: 9.009,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/second.ts',
     duration: 9.009,
     title: '',
     mediaSequenceNumber: 1,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/third.ts',
     duration: 3.003,
     title: '',
     mediaSequenceNumber: 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/8.10-EXT-X-DATERANGE-carrying-SCTE-35-tags.js
+++ b/test/fixtures/objects/8.10-EXT-X-DATERANGE-carrying-SCTE-35-tags.js
@@ -4,7 +4,7 @@ const utils = require('../../../utils');
 const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 30,
-  segments: createSegments()
+  segments: createSegments(),
 });
 
 function createSegments() {
@@ -15,14 +15,14 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: 0,
     discontinuitySequence: 0,
-    programDateTime: new Date('2014-03-05T11:14:00Z')
+    programDateTime: new Date('2014-03-05T11:14:00Z'),
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/02.ts',
     duration: 30,
     title: '',
     mediaSequenceNumber: 1,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://ads.example.com/ad-01.ts',
@@ -35,16 +35,16 @@ function createSegments() {
       start: new Date('2014-03-05T11:15:00Z'),
       plannedDuration: 59.993,
       attributes: {
-        'SCTE35-OUT': utils.hexToByteSequence('0xFC002F0000000000FF000014056FFFFFF000E011622DCAFF000052636200000000000A0008029896F50000008700000000')
-      }
-    })
+        'SCTE35-OUT': utils.hexToByteSequence('0xFC002F0000000000FF000014056FFFFFF000E011622DCAFF000052636200000000000A0008029896F50000008700000000'),
+      },
+    }),
   }));
   segments.push(new Segment({
     uri: 'http://ads.example.com/ad-02.ts',
     duration: 30,
     title: '',
     mediaSequenceNumber: 3,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/03.ts',
@@ -56,16 +56,16 @@ function createSegments() {
       id: 'splice-6FFFFFF0',
       duration: 59.993,
       attributes: {
-        'SCTE35-IN': utils.hexToByteSequence('0xFC002A0000000000FF00000F056FFFFFF000401162802E6100000000000A0008029896F50000008700000000')
-      }
-    })
+        'SCTE35-IN': utils.hexToByteSequence('0xFC002A0000000000FF00000F056FFFFFF000401162802E6100000000000A0008029896F50000008700000000'),
+      },
+    }),
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/04.ts',
     duration: 3.003,
     title: '',
     mediaSequenceNumber: 5,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/8.11-EXT-X-CUE-OUT-Media-Playlist.js
+++ b/test/fixtures/objects/8.11-EXT-X-CUE-OUT-Media-Playlist.js
@@ -4,7 +4,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 10,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -14,7 +14,7 @@ function createSegments() {
     duration: 9.009,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/second.ts',
@@ -24,15 +24,15 @@ function createSegments() {
     discontinuitySequence: 0,
     markers: [{
       type: 'OUT',
-      duration: 15
-    }]
+      duration: 15,
+    }],
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/third.ts',
     duration: 3.003,
     title: '',
     mediaSequenceNumber: 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/8.2-Live-Media-Playlist_using-HTTPS.js
+++ b/test/fixtures/objects/8.2-Live-Media-Playlist_using-HTTPS.js
@@ -6,7 +6,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   mediaSequenceBase,
-  segments: createSegments()
+  segments: createSegments(),
 });
 
 function createSegments() {
@@ -16,21 +16,21 @@ function createSegments() {
     duration: 7.975,
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'https://priv.example.com/fileSequence2681.ts',
     duration: 7.941,
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 1,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'https://priv.example.com/fileSequence2682.ts',
     duration: 7.975,
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/8.3-Playlist-with-encrypted-Media-Segments.js
+++ b/test/fixtures/objects/8.3-Playlist-with-encrypted-Media-Segments.js
@@ -9,7 +9,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 15,
   mediaSequenceBase,
-  segments: createSegments()
+  segments: createSegments(),
 });
 
 function createSegments() {
@@ -20,7 +20,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 0,
     discontinuitySequence: 0,
-    key: key1
+    key: key1,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/fileSequence52-B.ts',
@@ -28,7 +28,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 1,
     discontinuitySequence: 0,
-    key: key1
+    key: key1,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/fileSequence52-C.ts',
@@ -36,7 +36,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 2,
     discontinuitySequence: 0,
-    key: key1
+    key: key1,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/fileSequence53-A.ts',
@@ -44,7 +44,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: mediaSequenceBase + 3,
     discontinuitySequence: 0,
-    key: key2
+    key: key2,
   }));
   return segments;
 }

--- a/test/fixtures/objects/8.4-Master-Playlist.js
+++ b/test/fixtures/objects/8.4-Master-Playlist.js
@@ -1,7 +1,7 @@
 const {MasterPlaylist, Variant} = require('../../../types');
 
 const playlist = new MasterPlaylist({
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -10,24 +10,24 @@ function createVariants() {
     uri: 'http://example.com/low.m3u8',
     bandwidth: 1280000,
     averageBandwidth: 1000000,
-    codecs: 'avc1.640029,mp4a.40.2'
+    codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'http://example.com/mid.m3u8',
     bandwidth: 2560000,
     averageBandwidth: 2000000,
-    codecs: 'avc1.640029,mp4a.40.2'
+    codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'http://example.com/hi.m3u8',
     bandwidth: 7680000,
     averageBandwidth: 6000000,
-    codecs: 'avc1.640029,mp4a.40.2'
+    codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'http://example.com/audio-only.m3u8',
     bandwidth: 65000,
-    codecs: 'mp4a.40.5'
+    codecs: 'mp4a.40.5',
   }));
   return variants;
 }

--- a/test/fixtures/objects/8.4-Master-Playlist.js
+++ b/test/fixtures/objects/8.4-Master-Playlist.js
@@ -8,25 +8,25 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'http://example.com/low.m3u8',
-    bandwidth: 1280000,
-    averageBandwidth: 1000000,
+    bandwidth: 1_280_000,
+    averageBandwidth: 1_000_000,
     codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'http://example.com/mid.m3u8',
-    bandwidth: 2560000,
-    averageBandwidth: 2000000,
+    bandwidth: 2_560_000,
+    averageBandwidth: 2_000_000,
     codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'http://example.com/hi.m3u8',
-    bandwidth: 7680000,
-    averageBandwidth: 6000000,
+    bandwidth: 7_680_000,
+    averageBandwidth: 6_000_000,
     codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'http://example.com/audio-only.m3u8',
-    bandwidth: 65000,
+    bandwidth: 65_000,
     codecs: 'mp4a.40.5',
   }));
   return variants;

--- a/test/fixtures/objects/8.5-Master-Playlist-with-I-Frames.js
+++ b/test/fixtures/objects/8.5-Master-Playlist-with-I-Frames.js
@@ -8,40 +8,40 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'low/audio-video.m3u8',
-    bandwidth: 1280000,
+    bandwidth: 1_280_000,
     codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'low/iframe.m3u8',
     isIFrameOnly: true,
-    bandwidth: 86000,
+    bandwidth: 86_000,
     codecs: 'avc1.640029',
   }));
   variants.push(new Variant({
     uri: 'mid/audio-video.m3u8',
-    bandwidth: 2560000,
+    bandwidth: 2_560_000,
     codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'mid/iframe.m3u8',
     isIFrameOnly: true,
-    bandwidth: 150000,
+    bandwidth: 150_000,
     codecs: 'avc1.640029',
   }));
   variants.push(new Variant({
     uri: 'hi/audio-video.m3u8',
-    bandwidth: 7680000,
+    bandwidth: 7_680_000,
     codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'hi/iframe.m3u8',
     isIFrameOnly: true,
-    bandwidth: 550000,
+    bandwidth: 550_000,
     codecs: 'avc1.640029',
   }));
   variants.push(new Variant({
     uri: 'audio-only.m3u8',
-    bandwidth: 65000,
+    bandwidth: 65_000,
     codecs: 'mp4a.40.5',
   }));
   return variants;

--- a/test/fixtures/objects/8.5-Master-Playlist-with-I-Frames.js
+++ b/test/fixtures/objects/8.5-Master-Playlist-with-I-Frames.js
@@ -1,7 +1,7 @@
 const {MasterPlaylist, Variant} = require('../../../types');
 
 const playlist = new MasterPlaylist({
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -9,40 +9,40 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'low/audio-video.m3u8',
     bandwidth: 1280000,
-    codecs: 'avc1.640029,mp4a.40.2'
+    codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'low/iframe.m3u8',
     isIFrameOnly: true,
     bandwidth: 86000,
-    codecs: 'avc1.640029'
+    codecs: 'avc1.640029',
   }));
   variants.push(new Variant({
     uri: 'mid/audio-video.m3u8',
     bandwidth: 2560000,
-    codecs: 'avc1.640029,mp4a.40.2'
+    codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'mid/iframe.m3u8',
     isIFrameOnly: true,
     bandwidth: 150000,
-    codecs: 'avc1.640029'
+    codecs: 'avc1.640029',
   }));
   variants.push(new Variant({
     uri: 'hi/audio-video.m3u8',
     bandwidth: 7680000,
-    codecs: 'avc1.640029,mp4a.40.2'
+    codecs: 'avc1.640029,mp4a.40.2',
   }));
   variants.push(new Variant({
     uri: 'hi/iframe.m3u8',
     isIFrameOnly: true,
     bandwidth: 550000,
-    codecs: 'avc1.640029'
+    codecs: 'avc1.640029',
   }));
   variants.push(new Variant({
     uri: 'audio-only.m3u8',
     bandwidth: 65000,
-    codecs: 'mp4a.40.5'
+    codecs: 'mp4a.40.5',
   }));
   return variants;
 }

--- a/test/fixtures/objects/8.6-Master-Playlist-with-Alternative-audio.js
+++ b/test/fixtures/objects/8.6-Master-Playlist-with-Alternative-audio.js
@@ -42,28 +42,28 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'low/video-only.m3u8',
-    bandwidth: 1280000,
+    bandwidth: 1_280_000,
     codecs: 'mp4a.40.2',
     audio: renditions,
     currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'mid/video-only.m3u8',
-    bandwidth: 2560000,
+    bandwidth: 2_560_000,
     codecs: 'mp4a.40.2',
     audio: renditions,
     currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'hi/video-only.m3u8',
-    bandwidth: 7680000,
+    bandwidth: 7_680_000,
     codecs: 'mp4a.40.2',
     audio: renditions,
     currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'main/english-audio.m3u8',
-    bandwidth: 65000,
+    bandwidth: 65_000,
     codecs: 'mp4a.40.5',
     audio: renditions,
     currentRenditions: {audio: 0},

--- a/test/fixtures/objects/8.6-Master-Playlist-with-Alternative-audio.js
+++ b/test/fixtures/objects/8.6-Master-Playlist-with-Alternative-audio.js
@@ -11,7 +11,7 @@ function createRendition() {
     language: 'en',
     name: 'English',
     isDefault: true,
-    autoselect: true
+    autoselect: true,
   }));
   renditions.push(new Rendition({
     type: 'AUDIO',
@@ -20,7 +20,7 @@ function createRendition() {
     language: 'de',
     name: 'Deutsch',
     isDefault: false,
-    autoselect: true
+    autoselect: true,
   }));
   renditions.push(new Rendition({
     type: 'AUDIO',
@@ -29,13 +29,13 @@ function createRendition() {
     language: 'en',
     name: 'Commentary',
     isDefault: false,
-    autoselect: false
+    autoselect: false,
   }));
   return renditions;
 }
 
 const playlist = new MasterPlaylist({
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -45,28 +45,28 @@ function createVariants() {
     bandwidth: 1280000,
     codecs: 'mp4a.40.2',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'mid/video-only.m3u8',
     bandwidth: 2560000,
     codecs: 'mp4a.40.2',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'hi/video-only.m3u8',
     bandwidth: 7680000,
     codecs: 'mp4a.40.2',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'main/english-audio.m3u8',
     bandwidth: 65000,
     codecs: 'mp4a.40.5',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   return variants;
 }

--- a/test/fixtures/objects/8.7-Master-Playlist-with-Alternative-video.js
+++ b/test/fixtures/objects/8.7-Master-Playlist-with-Alternative-video.js
@@ -34,21 +34,21 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'low/main/audio-video.m3u8',
-    bandwidth: 1280000,
+    bandwidth: 1_280_000,
     codecs: 'avc1.640029,mp4a.40.2',
     video: createRendition('low'),
     currentRenditions: {video: 0},
   }));
   variants.push(new Variant({
     uri: 'mid/main/audio-video.m3u8',
-    bandwidth: 2560000,
+    bandwidth: 2_560_000,
     codecs: 'avc1.640029,mp4a.40.2',
     video: createRendition('mid'),
     currentRenditions: {video: 1},
   }));
   variants.push(new Variant({
     uri: 'hi/main/audio-video.m3u8',
-    bandwidth: 7680000,
+    bandwidth: 7_680_000,
     codecs: 'avc1.640029,mp4a.40.2',
     video: createRendition('hi'),
   }));

--- a/test/fixtures/objects/8.7-Master-Playlist-with-Alternative-video.js
+++ b/test/fixtures/objects/8.7-Master-Playlist-with-Alternative-video.js
@@ -7,27 +7,27 @@ function createRendition(groupId) {
     uri: `${groupId}/main/audio-video.m3u8`,
     groupId,
     name: 'Main',
-    isDefault: !(groupId === 'mid')
+    isDefault: !(groupId === 'mid'),
   }));
   renditions.push(new Rendition({
     type: 'VIDEO',
     uri: `${groupId}/centerfield/audio-video.m3u8`,
     groupId,
     name: 'Centerfield',
-    isDefault: groupId === 'mid'
+    isDefault: groupId === 'mid',
   }));
   renditions.push(new Rendition({
     type: 'VIDEO',
     uri: `${groupId}/dugout/audio-video.m3u8`,
     groupId,
     name: 'Dugout',
-    isDefault: false
+    isDefault: false,
   }));
   return renditions;
 }
 
 const playlist = new MasterPlaylist({
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -37,20 +37,20 @@ function createVariants() {
     bandwidth: 1280000,
     codecs: 'avc1.640029,mp4a.40.2',
     video: createRendition('low'),
-    currentRenditions: {video: 0}
+    currentRenditions: {video: 0},
   }));
   variants.push(new Variant({
     uri: 'mid/main/audio-video.m3u8',
     bandwidth: 2560000,
     codecs: 'avc1.640029,mp4a.40.2',
     video: createRendition('mid'),
-    currentRenditions: {video: 1}
+    currentRenditions: {video: 1},
   }));
   variants.push(new Variant({
     uri: 'hi/main/audio-video.m3u8',
     bandwidth: 7680000,
     codecs: 'avc1.640029,mp4a.40.2',
-    video: createRendition('hi')
+    video: createRendition('hi'),
   }));
   return variants;
 }

--- a/test/fixtures/objects/8.8-Session-Data-in-a-Master-Playlist.js
+++ b/test/fixtures/objects/8.8-Session-Data-in-a-Master-Playlist.js
@@ -1,24 +1,24 @@
 const {MasterPlaylist, SessionData} = require('../../../types');
 
 const playlist = new MasterPlaylist({
-  sessionDataList: createSetssionDataList()
+  sessionDataList: createSetssionDataList(),
 });
 
 function createSetssionDataList() {
   const setssionDataList = [];
   setssionDataList.push(new SessionData({
     id: 'com.example.lyrics',
-    uri: 'lyrics.json'
+    uri: 'lyrics.json',
   }));
   setssionDataList.push(new SessionData({
     id: 'com.example.title',
     language: 'en',
-    value: 'This is an example'
+    value: 'This is an example',
   }));
   setssionDataList.push(new SessionData({
     id: 'com.example.title',
     language: 'es',
-    value: 'Este es un ejemplo'
+    value: 'Este es un ejemplo',
   }));
   return setssionDataList;
 }

--- a/test/fixtures/objects/8.9-CHARACTERISTICS-attribute-containing-multiple-characteristics.js
+++ b/test/fixtures/objects/8.9-CHARACTERISTICS-attribute-containing-multiple-characteristics.js
@@ -45,28 +45,28 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'low/video-only.m3u8',
-    bandwidth: 1280000,
+    bandwidth: 1_280_000,
     codecs: 'mp4a.40.2',
     audio: renditions,
     currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'mid/video-only.m3u8',
-    bandwidth: 2560000,
+    bandwidth: 2_560_000,
     codecs: 'mp4a.40.2',
     audio: renditions,
     currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'hi/video-only.m3u8',
-    bandwidth: 7680000,
+    bandwidth: 7_680_000,
     codecs: 'mp4a.40.2',
     audio: renditions,
     currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'main/english-audio.m3u8',
-    bandwidth: 65000,
+    bandwidth: 65_000,
     codecs: 'mp4a.40.5',
     audio: renditions,
     currentRenditions: {audio: 0},

--- a/test/fixtures/objects/8.9-CHARACTERISTICS-attribute-containing-multiple-characteristics.js
+++ b/test/fixtures/objects/8.9-CHARACTERISTICS-attribute-containing-multiple-characteristics.js
@@ -12,7 +12,7 @@ function createRendition() {
     name: 'English',
     isDefault: true,
     autoselect: true,
-    characteristics: 'public.accessibility.transcribes-spoken-dialog,public.easy-to-read'
+    characteristics: 'public.accessibility.transcribes-spoken-dialog,public.easy-to-read',
   }));
   renditions.push(new Rendition({
     type: 'AUDIO',
@@ -22,7 +22,7 @@ function createRendition() {
     name: 'Deutsch',
     isDefault: false,
     autoselect: true,
-    characteristics: 'public.accessibility.transcribes-spoken-dialog,public.easy-to-read'
+    characteristics: 'public.accessibility.transcribes-spoken-dialog,public.easy-to-read',
   }));
   renditions.push(new Rendition({
     type: 'AUDIO',
@@ -32,13 +32,13 @@ function createRendition() {
     name: 'Commentary',
     isDefault: false,
     autoselect: false,
-    characteristics: 'public.accessibility.transcribes-spoken-dialog,public.easy-to-read'
+    characteristics: 'public.accessibility.transcribes-spoken-dialog,public.easy-to-read',
   }));
   return renditions;
 }
 
 const playlist = new MasterPlaylist({
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -48,28 +48,28 @@ function createVariants() {
     bandwidth: 1280000,
     codecs: 'mp4a.40.2',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'mid/video-only.m3u8',
     bandwidth: 2560000,
     codecs: 'mp4a.40.2',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'hi/video-only.m3u8',
     bandwidth: 7680000,
     codecs: 'mp4a.40.2',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   variants.push(new Variant({
     uri: 'main/english-audio.m3u8',
     bandwidth: 65000,
     codecs: 'mp4a.40.5',
     audio: renditions,
-    currentRenditions: {audio: 0}
+    currentRenditions: {audio: 0},
   }));
   return variants;
 }

--- a/test/fixtures/objects/Low-Latency_Example-01_Low-Latency_HLS_Playlist.js
+++ b/test/fixtures/objects/Low-Latency_Example-01_Low-Latency_HLS_Playlist.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   targetDuration: 4,
   mediaSequenceBase: 266,
   lowLatencyCompatibility: {canBlockReload: true, canSkipUntil: 24, partHoldBack: 1},
-  partTargetDuration: 0.33334,
+  partTargetDuration: 0.333_34,
   segments: createSegments(),
   renditionReports: createRenditionReports(),
 });
@@ -14,7 +14,7 @@ function createSegments() {
   const segments = [];
   segments.push(new Segment({
     uri: 'fileSequence266.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 266,
     discontinuitySequence: 0,
@@ -23,35 +23,35 @@ function createSegments() {
   }));
   segments.push(new Segment({
     uri: 'fileSequence267.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 267,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence268.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 268,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence269.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 269,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 270,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
@@ -59,7 +59,7 @@ function createSegments() {
   }));
   segments.push(new Segment({
     uri: 'fileSequence272.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 272,
     discontinuitySequence: 0,
@@ -93,7 +93,7 @@ function createParts1() {
   for (let i = 0; i < 12; i++) {
     parts.push(new PartialSegment({
       uri: `filePart271.${i}.mp4`,
-      duration: 0.33334,
+      duration: 0.333_34,
       independent: (i === 4 || i === 8),
     }));
   }
@@ -106,7 +106,7 @@ function createParts2() {
   for (let i = 0; i < 12; i++) {
     parts.push(new PartialSegment({
       uri: `filePart272.${String.fromCharCode(aCode + i)}.mp4`,
-      duration: 0.33334,
+      duration: 0.333_34,
       independent: (i === 5),
     }));
   }
@@ -118,7 +118,7 @@ function createParts3() {
   for (let i = 0; i < 4; i++) {
     parts.push(new PartialSegment({
       uri: `filePart273.${i}.mp4`,
-      duration: 0.33334,
+      duration: 0.333_34,
       independent: (i === 0),
       hint: (i === 3),
     }));

--- a/test/fixtures/objects/Low-Latency_Example-01_Low-Latency_HLS_Playlist.js
+++ b/test/fixtures/objects/Low-Latency_Example-01_Low-Latency_HLS_Playlist.js
@@ -7,7 +7,7 @@ const playlist = new MediaPlaylist({
   lowLatencyCompatibility: {canBlockReload: true, canSkipUntil: 24, partHoldBack: 1},
   partTargetDuration: 0.33334,
   segments: createSegments(),
-  renditionReports: createRenditionReports()
+  renditionReports: createRenditionReports(),
 });
 
 function createSegments() {
@@ -19,35 +19,35 @@ function createSegments() {
     mediaSequenceNumber: 266,
     discontinuitySequence: 0,
     programDateTime: new Date('2019-02-14T02:13:36.106Z'),
-    map: new MediaInitializationSection({uri: 'init.mp4'})
+    map: new MediaInitializationSection({uri: 'init.mp4'}),
   }));
   segments.push(new Segment({
     uri: 'fileSequence267.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 267,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence268.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 268,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence269.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 269,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 270,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
@@ -55,7 +55,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
-    parts: createParts1()
+    parts: createParts1(),
   }));
   segments.push(new Segment({
     uri: 'fileSequence272.mp4',
@@ -64,11 +64,11 @@ function createSegments() {
     mediaSequenceNumber: 272,
     discontinuitySequence: 0,
     programDateTime: new Date('2019-02-14T02:14:00.106Z'),
-    parts: createParts2()
+    parts: createParts2(),
   }));
   segments.push(new Segment({
     mediaSequenceNumber: 273,
-    parts: createParts3()
+    parts: createParts3(),
   }));
   return segments;
 }
@@ -78,12 +78,12 @@ function createRenditionReports() {
   reports.push(new RenditionReport({
     uri: '../1M/waitForMSN.php',
     lastMSN: 273,
-    lastPart: 2
+    lastPart: 2,
   }));
   reports.push(new RenditionReport({
     uri: '../4M/waitForMSN.php',
     lastMSN: 273,
-    lastPart: 1
+    lastPart: 1,
   }));
   return reports;
 }
@@ -94,7 +94,7 @@ function createParts1() {
     parts.push(new PartialSegment({
       uri: `filePart271.${i}.mp4`,
       duration: 0.33334,
-      independent: (i === 4 || i === 8)
+      independent: (i === 4 || i === 8),
     }));
   }
   return parts;
@@ -107,7 +107,7 @@ function createParts2() {
     parts.push(new PartialSegment({
       uri: `filePart272.${String.fromCharCode(aCode + i)}.mp4`,
       duration: 0.33334,
-      independent: (i === 5)
+      independent: (i === 5),
     }));
   }
   return parts;
@@ -120,7 +120,7 @@ function createParts3() {
       uri: `filePart273.${i}.mp4`,
       duration: 0.33334,
       independent: (i === 0),
-      hint: (i === 3)
+      hint: (i === 3),
     }));
   }
   return parts;

--- a/test/fixtures/objects/Low-Latency_Example-02_Playlist_Delta_Update.js
+++ b/test/fixtures/objects/Low-Latency_Example-02_Playlist_Delta_Update.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   targetDuration: 4,
   mediaSequenceBase: 266,
   lowLatencyCompatibility: {canBlockReload: true, canSkipUntil: 24.0, partHoldBack: 1.0},
-  partTargetDuration: 0.33334,
+  partTargetDuration: 0.333_34,
   skip: 3,
   segments: createSegments(),
   renditionReports: createRenditionReports(),
@@ -15,21 +15,21 @@ function createSegments() {
   const segments = [];
   segments.push(new Segment({
     uri: 'fileSequence269.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 269,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 270,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
@@ -37,7 +37,7 @@ function createSegments() {
   }));
   segments.push(new Segment({
     uri: 'fileSequence272.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 272,
     discontinuitySequence: 0,
@@ -71,7 +71,7 @@ function createParts1() {
   for (let i = 0; i < 12; i++) {
     parts.push(new PartialSegment({
       uri: `filePart271.${i}.mp4`,
-      duration: 0.33334,
+      duration: 0.333_34,
       independent: (i === 4 || i === 8),
     }));
   }
@@ -84,7 +84,7 @@ function createParts2() {
   for (let i = 0; i < 12; i++) {
     parts.push(new PartialSegment({
       uri: `filePart272.${String.fromCharCode(aCode + i)}.mp4`,
-      duration: 0.33334,
+      duration: 0.333_34,
       independent: (i === 5),
     }));
   }
@@ -96,7 +96,7 @@ function createParts3() {
   for (let i = 0; i < 5; i++) {
     parts.push(new PartialSegment({
       uri: `filePart273.${i}.mp4`,
-      duration: 0.33334,
+      duration: 0.333_34,
       independent: (i === 0),
       hint: (i === 4),
     }));

--- a/test/fixtures/objects/Low-Latency_Example-02_Playlist_Delta_Update.js
+++ b/test/fixtures/objects/Low-Latency_Example-02_Playlist_Delta_Update.js
@@ -8,7 +8,7 @@ const playlist = new MediaPlaylist({
   partTargetDuration: 0.33334,
   skip: 3,
   segments: createSegments(),
-  renditionReports: createRenditionReports()
+  renditionReports: createRenditionReports(),
 });
 
 function createSegments() {
@@ -18,14 +18,14 @@ function createSegments() {
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 269,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 270,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
@@ -33,7 +33,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
-    parts: createParts1()
+    parts: createParts1(),
   }));
   segments.push(new Segment({
     uri: 'fileSequence272.mp4',
@@ -42,11 +42,11 @@ function createSegments() {
     mediaSequenceNumber: 272,
     discontinuitySequence: 0,
     programDateTime: new Date('2019-02-14T02:14:00.106Z'),
-    parts: createParts2()
+    parts: createParts2(),
   }));
   segments.push(new Segment({
     mediaSequenceNumber: 273,
-    parts: createParts3()
+    parts: createParts3(),
   }));
   return segments;
 }
@@ -56,12 +56,12 @@ function createRenditionReports() {
   reports.push(new RenditionReport({
     uri: '../1M/waitForMSN.php',
     lastMSN: 273,
-    lastPart: 3
+    lastPart: 3,
   }));
   reports.push(new RenditionReport({
     uri: '../4M/waitForMSN.php',
     lastMSN: 273,
-    lastPart: 3
+    lastPart: 3,
   }));
   return reports;
 }
@@ -72,7 +72,7 @@ function createParts1() {
     parts.push(new PartialSegment({
       uri: `filePart271.${i}.mp4`,
       duration: 0.33334,
-      independent: (i === 4 || i === 8)
+      independent: (i === 4 || i === 8),
     }));
   }
   return parts;
@@ -85,7 +85,7 @@ function createParts2() {
     parts.push(new PartialSegment({
       uri: `filePart272.${String.fromCharCode(aCode + i)}.mp4`,
       duration: 0.33334,
-      independent: (i === 5)
+      independent: (i === 5),
     }));
   }
   return parts;
@@ -98,7 +98,7 @@ function createParts3() {
       uri: `filePart273.${i}.mp4`,
       duration: 0.33334,
       independent: (i === 0),
-      hint: (i === 4)
+      hint: (i === 4),
     }));
   }
   return parts;

--- a/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-01.js
+++ b/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-01.js
@@ -14,14 +14,14 @@ function createSegments() {
   const segments = [];
   segments.push(new Segment({
     uri: 'fileSequence269.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 269,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 270,
     discontinuitySequence: 0,
@@ -38,21 +38,21 @@ function createParts() {
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 0, length: 20000},
+    byterange: {offset: 0, length: 20_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 20000, length: 23000},
+    byterange: {offset: 20_000, length: 23_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 43000, length: 18000},
+    byterange: {offset: 43_000, length: 18_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
-    byterange: {offset: 61000},
+    byterange: {offset: 61_000},
     hint: true,
   }));
   return parts;

--- a/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-01.js
+++ b/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-01.js
@@ -7,7 +7,7 @@ const playlist = new MediaPlaylist({
   lowLatencyCompatibility: {canBlockReload: true, canSkipUntil: 24.0, partHoldBack: 1.02},
   partTargetDuration: 1.02,
   skip: 3,
-  segments: createSegments()
+  segments: createSegments(),
 });
 
 function createSegments() {
@@ -17,18 +17,18 @@ function createSegments() {
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 269,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 270,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     mediaSequenceNumber: 271,
-    parts: createParts()
+    parts: createParts(),
   }));
   return segments;
 }
@@ -38,22 +38,22 @@ function createParts() {
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 0, length: 20000}
+    byterange: {offset: 0, length: 20000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 20000, length: 23000}
+    byterange: {offset: 20000, length: 23000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 43000, length: 18000}
+    byterange: {offset: 43000, length: 18000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     byterange: {offset: 61000},
-    hint: true
+    hint: true,
   }));
   return parts;
 }

--- a/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-02.js
+++ b/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-02.js
@@ -14,21 +14,21 @@ function createSegments() {
   const segments = [];
   segments.push(new Segment({
     uri: 'fileSequence269.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 269,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 270,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
@@ -50,22 +50,22 @@ function createParts() {
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 0, length: 20000},
+    byterange: {offset: 0, length: 20_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 20000, length: 23000},
+    byterange: {offset: 20_000, length: 23_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 43000, length: 18000},
+    byterange: {offset: 43_000, length: 18_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 61000, length: 19000},
+    byterange: {offset: 61_000, length: 19_000},
   }));
   return parts;
 }

--- a/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-02.js
+++ b/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-02.js
@@ -7,7 +7,7 @@ const playlist = new MediaPlaylist({
   lowLatencyCompatibility: {canBlockReload: true, canSkipUntil: 24.0, partHoldBack: 1.02},
   partTargetDuration: 1.02,
   skip: 3,
-  segments: createSegments()
+  segments: createSegments(),
 });
 
 function createSegments() {
@@ -17,14 +17,14 @@ function createSegments() {
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 269,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 270,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
@@ -32,15 +32,15 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
-    parts: createParts()
+    parts: createParts(),
   }));
   segments.push(new Segment({
     mediaSequenceNumber: 272,
     parts: [new PartialSegment({
       uri: 'fileSequence272.mp4',
       byterange: {offset: 0},
-      hint: true
-    })]
+      hint: true,
+    })],
   }));
   return segments;
 }
@@ -50,22 +50,22 @@ function createParts() {
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 0, length: 20000}
+    byterange: {offset: 0, length: 20000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 20000, length: 23000}
+    byterange: {offset: 20000, length: 23000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 43000, length: 18000}
+    byterange: {offset: 43000, length: 18000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 61000, length: 19000}
+    byterange: {offset: 61000, length: 19000},
   }));
   return parts;
 }

--- a/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-03.js
+++ b/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-03.js
@@ -14,21 +14,21 @@ function createSegments() {
   const segments = [];
   segments.push(new Segment({
     uri: 'fileSequence269.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 269,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 270,
     discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
-    duration: 4.00008,
+    duration: 4.000_08,
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
@@ -40,11 +40,11 @@ function createSegments() {
       new PartialSegment({
         uri: 'fileSequence272.mp4',
         duration: 1.02,
-        byterange: {offset: 0, length: 21000},
+        byterange: {offset: 0, length: 21_000},
       }),
       new PartialSegment({
         uri: 'fileSequence272.mp4',
-        byterange: {offset: 21000},
+        byterange: {offset: 21_000},
         hint: true,
       }),
     ],
@@ -57,22 +57,22 @@ function createParts() {
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 0, length: 20000},
+    byterange: {offset: 0, length: 20_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 20000, length: 23000},
+    byterange: {offset: 20_000, length: 23_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 43000, length: 18000},
+    byterange: {offset: 43_000, length: 18_000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 61000, length: 19000},
+    byterange: {offset: 61_000, length: 19_000},
   }));
   return parts;
 }

--- a/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-03.js
+++ b/test/fixtures/objects/Low-Latency_Example-03_Byterange-addressed_Parts-03.js
@@ -7,7 +7,7 @@ const playlist = new MediaPlaylist({
   lowLatencyCompatibility: {canBlockReload: true, canSkipUntil: 24.0, partHoldBack: 1.02},
   partTargetDuration: 1.02,
   skip: 3,
-  segments: createSegments()
+  segments: createSegments(),
 });
 
 function createSegments() {
@@ -17,14 +17,14 @@ function createSegments() {
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 269,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence270.mp4',
     duration: 4.00008,
     title: '',
     mediaSequenceNumber: 270,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'fileSequence271.mp4',
@@ -32,7 +32,7 @@ function createSegments() {
     title: '',
     mediaSequenceNumber: 271,
     discontinuitySequence: 0,
-    parts: createParts()
+    parts: createParts(),
   }));
   segments.push(new Segment({
     mediaSequenceNumber: 272,
@@ -40,14 +40,14 @@ function createSegments() {
       new PartialSegment({
         uri: 'fileSequence272.mp4',
         duration: 1.02,
-        byterange: {offset: 0, length: 21000}
+        byterange: {offset: 0, length: 21000},
       }),
       new PartialSegment({
         uri: 'fileSequence272.mp4',
         byterange: {offset: 21000},
-        hint: true
-      })
-    ]
+        hint: true,
+      }),
+    ],
   }));
   return segments;
 }
@@ -57,22 +57,22 @@ function createParts() {
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 0, length: 20000}
+    byterange: {offset: 0, length: 20000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 20000, length: 23000}
+    byterange: {offset: 20000, length: 23000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 43000, length: 18000}
+    byterange: {offset: 43000, length: 18000},
   }));
   parts.push(new PartialSegment({
     uri: 'fileSequence271.mp4',
     duration: 1.02,
-    byterange: {offset: 61000, length: 19000}
+    byterange: {offset: 61000, length: 19000},
   }));
   return parts;
 }

--- a/test/fixtures/objects/RedundantSegments.js
+++ b/test/fixtures/objects/RedundantSegments.js
@@ -4,7 +4,7 @@ const playlist = new MediaPlaylist({
   version: 4,
   targetDuration: 10,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -14,14 +14,14 @@ function createSegments() {
     duration: 9.009,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/second.ts',
     duration: 9.009,
     title: '',
     mediaSequenceNumber: 1,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/second.ts',
@@ -29,14 +29,14 @@ function createSegments() {
     duration: 9.009,
     title: '',
     mediaSequenceNumber: 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: 'http://media.example.com/third.ts',
     duration: 3.003,
     title: '',
     mediaSequenceNumber: 3,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/SCTE-35_01.js
+++ b/test/fixtures/objects/SCTE-35_01.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -15,7 +15,7 @@ function createSegments() {
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '2.ts',
@@ -25,15 +25,15 @@ function createSegments() {
     discontinuitySequence: 0,
     markers: [{
       type: 'OUT',
-      duration: 15.0
-    }]
+      duration: 15.0,
+    }],
   }));
   segments.push(new Segment({
     uri: '3.ts',
     duration: 7,
     title: '',
     mediaSequenceNumber: 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '4.ts',
@@ -42,15 +42,15 @@ function createSegments() {
     mediaSequenceNumber: 3,
     discontinuitySequence: 0,
     markers: [{
-      type: 'IN'
-    }]
+      type: 'IN',
+    }],
   }));
   segments.push(new Segment({
     uri: '5.ts',
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 4,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/SCTE-35_02.js
+++ b/test/fixtures/objects/SCTE-35_02.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -15,7 +15,7 @@ function createSegments() {
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '2.ts',
@@ -25,8 +25,8 @@ function createSegments() {
     discontinuitySequence: 0,
     markers: [{
       type: 'OUT',
-      duration: 23.0
-    }]
+      duration: 23.0,
+    }],
   }));
   segments.push(new Segment({
     uri: '3.ts',
@@ -37,8 +37,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=8,Duration=23'
-    }]
+      value: 'ElapsedTime=8,Duration=23',
+    }],
   }));
   segments.push(new Segment({
     uri: '4.ts',
@@ -49,8 +49,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=16,Duration=23'
-    }]
+      value: 'ElapsedTime=16,Duration=23',
+    }],
   }));
   segments.push(new Segment({
     uri: '5.ts',
@@ -59,8 +59,8 @@ function createSegments() {
     mediaSequenceNumber: 4,
     discontinuitySequence: 0,
     markers: [{
-      type: 'IN'
-    }]
+      type: 'IN',
+    }],
   }));
   return segments;
 }

--- a/test/fixtures/objects/SCTE-35_03.js
+++ b/test/fixtures/objects/SCTE-35_03.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -15,7 +15,7 @@ function createSegments() {
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '2.ts',
@@ -26,29 +26,29 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE',
-      value: 'DURATION="15.0",ID="0",TYPE="SpliceOut",TIME="414.171"'
-    }]
+      value: 'DURATION="15.0",ID="0",TYPE="SpliceOut",TIME="414.171"',
+    }],
   }));
   segments.push(new Segment({
     uri: '3.ts',
     duration: 7,
     title: '',
     mediaSequenceNumber: 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '4.ts',
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 3,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '5.ts',
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 4,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/SCTE-35_04.js
+++ b/test/fixtures/objects/SCTE-35_04.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -15,7 +15,7 @@ function createSegments() {
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '2.ts',
@@ -27,18 +27,18 @@ function createSegments() {
       {
         type: 'RAW',
         tagName: 'EXT-OATCLS-SCTE35',
-        value: '/DA0AAAAAAAAAAAABQb+ADAQ6QAeAhxDVUVJQAAAO3/PAAEUrEoICAAAAAAg+2UBNAAANvrtoQ=='
+        value: '/DA0AAAAAAAAAAAABQb+ADAQ6QAeAhxDVUVJQAAAO3/PAAEUrEoICAAAAAAg+2UBNAAANvrtoQ==',
       },
       {
         type: 'RAW',
         tagName: 'EXT-X-ASSET',
-        value: 'CAID=0x0000000020FB6501'
+        value: 'CAID=0x0000000020FB6501',
       },
       {
         type: 'OUT',
-        duration: 15.0
-      }
-    ]
+        duration: 15.0,
+      },
+    ],
   }));
   segments.push(new Segment({
     uri: '3.ts',
@@ -49,8 +49,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=5.939,Duration=25.0,SCTE35=/DA0AAAA+…AAg+2UBNAAANvrtoQ=='
-    }]
+      value: 'ElapsedTime=5.939,Duration=25.0,SCTE35=/DA0AAAA+…AAg+2UBNAAANvrtoQ==',
+    }],
   }));
   segments.push(new Segment({
     uri: '4.ts',
@@ -59,15 +59,15 @@ function createSegments() {
     mediaSequenceNumber: 3,
     discontinuitySequence: 0,
     markers: [{
-      type: 'IN'
-    }]
+      type: 'IN',
+    }],
   }));
   segments.push(new Segment({
     uri: '5.ts',
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 4,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/SCTE-35_05.js
+++ b/test/fixtures/objects/SCTE-35_05.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -15,7 +15,7 @@ function createSegments() {
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '2.ts',
@@ -26,15 +26,15 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-SCTE35',
-      value: 'TYPE=0x34,DURATION=15.0,CUE-OUT=YES,UPID="0x08:0x9425BC",CUE=”/DA0AAAA+…AAg+2UBNAAANvrtoQ==”,ID=”pIViS5”'
-    }]
+      value: 'TYPE=0x34,DURATION=15.0,CUE-OUT=YES,UPID="0x08:0x9425BC",CUE=”/DA0AAAA+…AAg+2UBNAAANvrtoQ==”,ID=”pIViS5”',
+    }],
   }));
   segments.push(new Segment({
     uri: '3.ts',
     duration: 7,
     title: '',
     mediaSequenceNumber: 2,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '4.ts',
@@ -45,15 +45,15 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-SCTE35',
-      value: 'TYPE=0x35,CUE-IN=YES,CUE=”/DA0AAAA+…AAg+2UBNAAANvrtoQ==”,ID=”f6UrRd”'
-    }]
+      value: 'TYPE=0x35,CUE-IN=YES,CUE=”/DA0AAAA+…AAg+2UBNAAANvrtoQ==”,ID=”f6UrRd”',
+    }],
   }));
   segments.push(new Segment({
     uri: '5.ts',
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 4,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   return segments;
 }

--- a/test/fixtures/objects/SCTE-35_06.js
+++ b/test/fixtures/objects/SCTE-35_06.js
@@ -5,7 +5,7 @@ const playlist = new MediaPlaylist({
   version: 3,
   targetDuration: 8,
   segments: createSegments(),
-  endlist: true
+  endlist: true,
 });
 
 function createSegments() {
@@ -15,7 +15,7 @@ function createSegments() {
     duration: 8.008,
     title: '',
     mediaSequenceNumber: 0,
-    discontinuitySequence: 0
+    discontinuitySequence: 0,
   }));
   segments.push(new Segment({
     uri: '2.ts',
@@ -25,8 +25,8 @@ function createSegments() {
     discontinuitySequence: 0,
     markers: [{
       type: 'OUT',
-      duration: 23.0
-    }]
+      duration: 23.0,
+    }],
   }));
   segments.push(new Segment({
     uri: '3.ts',
@@ -37,8 +37,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=8,Duration=23'
-    }]
+      value: 'ElapsedTime=8,Duration=23',
+    }],
   }));
   segments.push(new Segment({
     uri: '4.ts',
@@ -49,8 +49,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=16,Duration=23'
-    }]
+      value: 'ElapsedTime=16,Duration=23',
+    }],
   }));
   segments.push(new Segment({
     uri: '5.ts',
@@ -59,8 +59,8 @@ function createSegments() {
     mediaSequenceNumber: 4,
     discontinuitySequence: 0,
     markers: [{
-      type: 'IN'
-    }]
+      type: 'IN',
+    }],
   }));
   segments.push(new Segment({
     uri: '6.ts',
@@ -70,8 +70,8 @@ function createSegments() {
     discontinuitySequence: 0,
     markers: [{
       type: 'OUT',
-      duration: 23.0
-    }]
+      duration: 23.0,
+    }],
   }));
   segments.push(new Segment({
     uri: '7.ts',
@@ -82,8 +82,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=8,Duration=23'
-    }]
+      value: 'ElapsedTime=8,Duration=23',
+    }],
   }));
   segments.push(new Segment({
     uri: '8.ts',
@@ -94,8 +94,8 @@ function createSegments() {
     markers: [{
       type: 'RAW',
       tagName: 'EXT-X-CUE-OUT-CONT',
-      value: 'ElapsedTime=16,Duration=23'
-    }]
+      value: 'ElapsedTime=16,Duration=23',
+    }],
   }));
   segments.push(new Segment({
     uri: '9.ts',
@@ -104,8 +104,8 @@ function createSegments() {
     mediaSequenceNumber: 8,
     discontinuitySequence: 0,
     markers: [{
-      type: 'IN'
-    }]
+      type: 'IN',
+    }],
   }));
   return segments;
 }

--- a/test/fixtures/objects/Streaming-Examples_bipbop_16x9_variant.js
+++ b/test/fixtures/objects/Streaming-Examples_bipbop_16x9_variant.js
@@ -8,7 +8,7 @@ const renditions = {
       language: 'eng',
       name: 'BipBop Audio 1',
       autoselect: true,
-      isDefault: true
+      isDefault: true,
     }),
     new Rendition({
       type: 'AUDIO',
@@ -17,8 +17,8 @@ const renditions = {
       language: 'eng',
       name: 'BipBop Audio 2',
       autoselect: false,
-      isDefault: false
-    })
+      isDefault: false,
+    }),
   ],
   subs: [
     new Rendition({
@@ -30,7 +30,7 @@ const renditions = {
       autoselect: true,
       isDefault: true,
       forced: false,
-      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound'
+      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound',
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -40,7 +40,7 @@ const renditions = {
       name: 'English (Forced)',
       autoselect: false,
       isDefault: false,
-      forced: true
+      forced: true,
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -51,7 +51,7 @@ const renditions = {
       autoselect: true,
       isDefault: false,
       forced: false,
-      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound'
+      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound',
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -61,7 +61,7 @@ const renditions = {
       name: 'Français (Forced)',
       autoselect: false,
       isDefault: false,
-      forced: true
+      forced: true,
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -72,7 +72,7 @@ const renditions = {
       autoselect: true,
       isDefault: false,
       forced: false,
-      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound'
+      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound',
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -82,7 +82,7 @@ const renditions = {
       name: 'Español (Forced)',
       autoselect: false,
       isDefault: false,
-      forced: true
+      forced: true,
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -93,7 +93,7 @@ const renditions = {
       autoselect: true,
       isDefault: false,
       forced: false,
-      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound'
+      characteristics: 'public.accessibility.transcribes-spoken-dialog, public.accessibility.describes-music-and-sound',
     }),
     new Rendition({
       type: 'SUBTITLES',
@@ -103,13 +103,13 @@ const renditions = {
       name: '日本語 (Forced)',
       autoselect: false,
       isDefault: false,
-      forced: true
-    })
-  ]
+      forced: true,
+    }),
+  ],
 };
 
 const playlist = new MasterPlaylist({
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -120,13 +120,13 @@ function createVariants() {
     codecs: 'mp4a.40.2, avc1.4d400d',
     resolution: {width: 416, height: 234},
     audio: renditions.bipbop_audio,
-    subtitles: renditions.subs
+    subtitles: renditions.subs,
   }));
   variants.push(new Variant({
     uri: 'gear1/iframe_index.m3u8',
     isIFrameOnly: true,
     bandwidth: 28451,
-    codecs: 'avc1.4d400d'
+    codecs: 'avc1.4d400d',
   }));
   variants.push(new Variant({
     uri: 'gear2/prog_index.m3u8',
@@ -134,13 +134,13 @@ function createVariants() {
     codecs: 'mp4a.40.2, avc1.4d401e',
     resolution: {width: 640, height: 360},
     audio: renditions.bipbop_audio,
-    subtitles: renditions.subs
+    subtitles: renditions.subs,
   }));
   variants.push(new Variant({
     uri: 'gear2/iframe_index.m3u8',
     isIFrameOnly: true,
     bandwidth: 181534,
-    codecs: 'avc1.4d401e'
+    codecs: 'avc1.4d401e',
   }));
   variants.push(new Variant({
     uri: 'gear3/prog_index.m3u8',
@@ -148,13 +148,13 @@ function createVariants() {
     codecs: 'mp4a.40.2, avc1.4d401f',
     resolution: {width: 960, height: 540},
     audio: renditions.bipbop_audio,
-    subtitles: renditions.subs
+    subtitles: renditions.subs,
   }));
   variants.push(new Variant({
     uri: 'gear3/iframe_index.m3u8',
     isIFrameOnly: true,
     bandwidth: 297056,
-    codecs: 'avc1.4d401f'
+    codecs: 'avc1.4d401f',
   }));
   variants.push(new Variant({
     uri: 'gear4/prog_index.m3u8',
@@ -162,13 +162,13 @@ function createVariants() {
     codecs: 'mp4a.40.2, avc1.4d401f',
     resolution: {width: 1280, height: 720},
     audio: renditions.bipbop_audio,
-    subtitles: renditions.subs
+    subtitles: renditions.subs,
   }));
   variants.push(new Variant({
     uri: 'gear4/iframe_index.m3u8',
     isIFrameOnly: true,
     bandwidth: 339492,
-    codecs: 'avc1.4d401f'
+    codecs: 'avc1.4d401f',
   }));
   variants.push(new Variant({
     uri: 'gear5/prog_index.m3u8',
@@ -176,20 +176,20 @@ function createVariants() {
     codecs: 'mp4a.40.2, avc1.4d401f',
     resolution: {width: 1920, height: 1080},
     audio: renditions.bipbop_audio,
-    subtitles: renditions.subs
+    subtitles: renditions.subs,
   }));
   variants.push(new Variant({
     uri: 'gear5/iframe_index.m3u8',
     isIFrameOnly: true,
     bandwidth: 669554,
-    codecs: 'avc1.4d401f'
+    codecs: 'avc1.4d401f',
   }));
   variants.push(new Variant({
     uri: 'gear0/prog_index.m3u8',
     bandwidth: 41457,
     codecs: 'mp4a.40.2',
     audio: renditions.bipbop_audio,
-    subtitles: renditions.subs
+    subtitles: renditions.subs,
   }));
   return variants;
 }

--- a/test/fixtures/objects/Streaming-Examples_bipbop_16x9_variant.js
+++ b/test/fixtures/objects/Streaming-Examples_bipbop_16x9_variant.js
@@ -116,7 +116,7 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'gear1/prog_index.m3u8',
-    bandwidth: 263851,
+    bandwidth: 263_851,
     codecs: 'mp4a.40.2, avc1.4d400d',
     resolution: {width: 416, height: 234},
     audio: renditions.bipbop_audio,
@@ -125,12 +125,12 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'gear1/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 28451,
+    bandwidth: 28_451,
     codecs: 'avc1.4d400d',
   }));
   variants.push(new Variant({
     uri: 'gear2/prog_index.m3u8',
-    bandwidth: 577610,
+    bandwidth: 577_610,
     codecs: 'mp4a.40.2, avc1.4d401e',
     resolution: {width: 640, height: 360},
     audio: renditions.bipbop_audio,
@@ -139,12 +139,12 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'gear2/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 181534,
+    bandwidth: 181_534,
     codecs: 'avc1.4d401e',
   }));
   variants.push(new Variant({
     uri: 'gear3/prog_index.m3u8',
-    bandwidth: 915905,
+    bandwidth: 915_905,
     codecs: 'mp4a.40.2, avc1.4d401f',
     resolution: {width: 960, height: 540},
     audio: renditions.bipbop_audio,
@@ -153,12 +153,12 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'gear3/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 297056,
+    bandwidth: 297_056,
     codecs: 'avc1.4d401f',
   }));
   variants.push(new Variant({
     uri: 'gear4/prog_index.m3u8',
-    bandwidth: 1030138,
+    bandwidth: 1_030_138,
     codecs: 'mp4a.40.2, avc1.4d401f',
     resolution: {width: 1280, height: 720},
     audio: renditions.bipbop_audio,
@@ -167,12 +167,12 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'gear4/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 339492,
+    bandwidth: 339_492,
     codecs: 'avc1.4d401f',
   }));
   variants.push(new Variant({
     uri: 'gear5/prog_index.m3u8',
-    bandwidth: 1924009,
+    bandwidth: 1_924_009,
     codecs: 'mp4a.40.2, avc1.4d401f',
     resolution: {width: 1920, height: 1080},
     audio: renditions.bipbop_audio,
@@ -181,12 +181,12 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'gear5/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 669554,
+    bandwidth: 669_554,
     codecs: 'avc1.4d401f',
   }));
   variants.push(new Variant({
     uri: 'gear0/prog_index.m3u8',
-    bandwidth: 41457,
+    bandwidth: 41_457,
     codecs: 'mp4a.40.2',
     audio: renditions.bipbop_audio,
     subtitles: renditions.subs,

--- a/test/fixtures/objects/Streaming-Examples_img_bipbop_adv_example_ts_master.js
+++ b/test/fixtures/objects/Streaming-Examples_img_bipbop_adv_example_ts_master.js
@@ -72,8 +72,8 @@ function createVariants() {
   const variants = [];
   variants.push(new Variant({
     uri: 'v5/prog_index.m3u8',
-    bandwidth: 2227464,
-    averageBandwidth: 2218327,
+    bandwidth: 2_227_464,
+    averageBandwidth: 2_218_327,
     codecs: 'avc1.640020,mp4a.40.2',
     resolution: {width: 960, height: 540},
     frameRate: 60.0,
@@ -83,8 +83,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v9/prog_index.m3u8',
-    bandwidth: 8178040,
-    averageBandwidth: 8144656,
+    bandwidth: 8_178_040,
+    averageBandwidth: 8_144_656,
     codecs: 'avc1.64002a,mp4a.40.2',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -94,8 +94,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v8/prog_index.m3u8',
-    bandwidth: 6453202,
-    averageBandwidth: 6307144,
+    bandwidth: 6_453_202,
+    averageBandwidth: 6_307_144,
     codecs: 'avc1.64002a,mp4a.40.2',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -105,8 +105,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v7/prog_index.m3u8',
-    bandwidth: 5054232,
-    averageBandwidth: 4775338,
+    bandwidth: 5_054_232,
+    averageBandwidth: 4_775_338,
     codecs: 'avc1.64002a,mp4a.40.2',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -116,8 +116,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v6/prog_index.m3u8',
-    bandwidth: 3289288,
-    averageBandwidth: 3240596,
+    bandwidth: 3_289_288,
+    averageBandwidth: 3_240_596,
     codecs: 'avc1.640020,mp4a.40.2',
     resolution: {width: 1280, height: 720},
     frameRate: 60.0,
@@ -127,8 +127,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v4/prog_index.m3u8',
-    bandwidth: 1296989,
-    averageBandwidth: 1292926,
+    bandwidth: 1_296_989,
+    averageBandwidth: 1_292_926,
     codecs: 'avc1.64001e,mp4a.40.2',
     resolution: {width: 768, height: 432},
     frameRate: 30.0,
@@ -138,8 +138,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v3/prog_index.m3u8',
-    bandwidth: 922242,
-    averageBandwidth: 914722,
+    bandwidth: 922_242,
+    averageBandwidth: 914_722,
     codecs: 'avc1.64001e,mp4a.40.2',
     resolution: {width: 640, height: 360},
     frameRate: 30.0,
@@ -149,8 +149,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v2/prog_index.m3u8',
-    bandwidth: 553010,
-    averageBandwidth: 541239,
+    bandwidth: 553_010,
+    averageBandwidth: 541_239,
     codecs: 'avc1.640015,mp4a.40.2',
     resolution: {width: 480, height: 270},
     frameRate: 30.0,
@@ -160,8 +160,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v5/prog_index.m3u8',
-    bandwidth: 2448841,
-    averageBandwidth: 2439704,
+    bandwidth: 2_448_841,
+    averageBandwidth: 2_439_704,
     codecs: 'avc1.640020,ac-3',
     resolution: {width: 960, height: 540},
     frameRate: 60.0,
@@ -171,8 +171,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v9/prog_index.m3u8',
-    bandwidth: 8399417,
-    averageBandwidth: 8366033,
+    bandwidth: 8_399_417,
+    averageBandwidth: 8_366_033,
     codecs: 'avc1.64002a,ac-3',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -182,8 +182,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v8/prog_index.m3u8',
-    bandwidth: 6674579,
-    averageBandwidth: 6528521,
+    bandwidth: 6_674_579,
+    averageBandwidth: 6_528_521,
     codecs: 'avc1.64002a,ac-3',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -193,8 +193,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v7/prog_index.m3u8',
-    bandwidth: 5275609,
-    averageBandwidth: 4996715,
+    bandwidth: 5_275_609,
+    averageBandwidth: 4_996_715,
     codecs: 'avc1.64002a,ac-3',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -204,8 +204,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v6/prog_index.m3u8',
-    bandwidth: 3510665,
-    averageBandwidth: 3461973,
+    bandwidth: 3_510_665,
+    averageBandwidth: 3_461_973,
     codecs: 'avc1.640020,ac-3',
     resolution: {width: 1280, height: 720},
     frameRate: 60.0,
@@ -215,8 +215,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v4/prog_index.m3u8',
-    bandwidth: 1518366,
-    averageBandwidth: 1514303,
+    bandwidth: 1_518_366,
+    averageBandwidth: 1_514_303,
     codecs: 'avc1.64001e,ac-3',
     resolution: {width: 768, height: 432},
     frameRate: 30.0,
@@ -226,8 +226,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v3/prog_index.m3u8',
-    bandwidth: 1143619,
-    averageBandwidth: 1136099,
+    bandwidth: 1_143_619,
+    averageBandwidth: 1_136_099,
     codecs: 'avc1.64001e,ac-3',
     resolution: {width: 640, height: 360},
     frameRate: 30.0,
@@ -237,8 +237,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v2/prog_index.m3u8',
-    bandwidth: 774387,
-    averageBandwidth: 762616,
+    bandwidth: 774_387,
+    averageBandwidth: 762_616,
     codecs: 'avc1.640015,ac-3',
     resolution: {width: 480, height: 270},
     frameRate: 30.0,
@@ -248,8 +248,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v5/prog_index.m3u8',
-    bandwidth: 2256841,
-    averageBandwidth: 2247704,
+    bandwidth: 2_256_841,
+    averageBandwidth: 2_247_704,
     codecs: 'avc1.640020,ec-3',
     resolution: {width: 960, height: 540},
     frameRate: 60.0,
@@ -259,8 +259,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v9/prog_index.m3u8',
-    bandwidth: 8207417,
-    averageBandwidth: 8174033,
+    bandwidth: 8_207_417,
+    averageBandwidth: 8_174_033,
     codecs: 'avc1.64002a,ec-3',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -270,8 +270,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v8/prog_index.m3u8',
-    bandwidth: 6482579,
-    averageBandwidth: 6336521,
+    bandwidth: 6_482_579,
+    averageBandwidth: 6_336_521,
     codecs: 'avc1.64002a,ec-3',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -281,8 +281,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v7/prog_index.m3u8',
-    bandwidth: 5083609,
-    averageBandwidth: 4804715,
+    bandwidth: 5_083_609,
+    averageBandwidth: 4_804_715,
     codecs: 'avc1.64002a,ec-3',
     resolution: {width: 1920, height: 1080},
     frameRate: 60.0,
@@ -292,8 +292,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v6/prog_index.m3u8',
-    bandwidth: 3318665,
-    averageBandwidth: 3269973,
+    bandwidth: 3_318_665,
+    averageBandwidth: 3_269_973,
     codecs: 'avc1.640020,ec-3',
     resolution: {width: 1280, height: 720},
     frameRate: 60.0,
@@ -303,8 +303,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v4/prog_index.m3u8',
-    bandwidth: 1326366,
-    averageBandwidth: 1322303,
+    bandwidth: 1_326_366,
+    averageBandwidth: 1_322_303,
     codecs: 'avc1.64001e,ec-3',
     resolution: {width: 768, height: 432},
     frameRate: 30.0,
@@ -314,8 +314,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v3/prog_index.m3u8',
-    bandwidth: 951619,
-    averageBandwidth: 944099,
+    bandwidth: 951_619,
+    averageBandwidth: 944_099,
     codecs: 'avc1.64001e,ec-3',
     resolution: {width: 640, height: 360},
     frameRate: 30.0,
@@ -325,8 +325,8 @@ function createVariants() {
   }));
   variants.push(new Variant({
     uri: 'v2/prog_index.m3u8',
-    bandwidth: 582387,
-    averageBandwidth: 570616,
+    bandwidth: 582_387,
+    averageBandwidth: 570_616,
     codecs: 'avc1.640015,ec-3',
     resolution: {width: 480, height: 270},
     frameRate: 30.0,
@@ -337,48 +337,48 @@ function createVariants() {
   variants.push(new Variant({
     uri: 'v7/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 186522,
-    averageBandwidth: 182077,
+    bandwidth: 186_522,
+    averageBandwidth: 182_077,
     codecs: 'avc1.64002a',
     resolution: {width: 1920, height: 1080},
   }));
   variants.push(new Variant({
     uri: 'v6/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 133856,
-    averageBandwidth: 129936,
+    bandwidth: 133_856,
+    averageBandwidth: 129_936,
     codecs: 'avc1.640020',
     resolution: {width: 1280, height: 720},
   }));
   variants.push(new Variant({
     uri: 'v5/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 98136,
-    averageBandwidth: 94286,
+    bandwidth: 98_136,
+    averageBandwidth: 94_286,
     codecs: 'avc1.640020',
     resolution: {width: 960, height: 540},
   }));
   variants.push(new Variant({
     uri: 'v4/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 76704,
-    averageBandwidth: 74767,
+    bandwidth: 76_704,
+    averageBandwidth: 74_767,
     codecs: 'avc1.64001e',
     resolution: {width: 768, height: 432},
   }));
   variants.push(new Variant({
     uri: 'v3/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 64078,
-    averageBandwidth: 62251,
+    bandwidth: 64_078,
+    averageBandwidth: 62_251,
     codecs: 'avc1.64001e',
     resolution: {width: 640, height: 360},
   }));
   variants.push(new Variant({
     uri: 'v2/iframe_index.m3u8',
     isIFrameOnly: true,
-    bandwidth: 38728,
-    averageBandwidth: 37866,
+    bandwidth: 38_728,
+    averageBandwidth: 37_866,
     codecs: 'avc1.640015',
     resolution: {width: 480, height: 270},
   }));

--- a/test/fixtures/objects/Streaming-Examples_img_bipbop_adv_example_ts_master.js
+++ b/test/fixtures/objects/Streaming-Examples_img_bipbop_adv_example_ts_master.js
@@ -10,8 +10,8 @@ const renditions = {
       name: 'English',
       autoselect: true,
       isDefault: true,
-      channels: '2'
-    })
+      channels: '2',
+    }),
   ],
   aud2: [
     new Rendition({
@@ -22,8 +22,8 @@ const renditions = {
       name: 'English',
       autoselect: true,
       isDefault: true,
-      channels: '6'
-    })
+      channels: '6',
+    }),
   ],
   aud3: [
     new Rendition({
@@ -34,8 +34,8 @@ const renditions = {
       name: 'English',
       autoselect: true,
       isDefault: true,
-      channels: '6'
-    })
+      channels: '6',
+    }),
   ],
   cc1: [
     new Rendition({
@@ -45,8 +45,8 @@ const renditions = {
       name: 'English',
       autoselect: true,
       isDefault: true,
-      instreamId: 'CC1'
-    })
+      instreamId: 'CC1',
+    }),
   ],
   sub1: [
     new Rendition({
@@ -57,15 +57,15 @@ const renditions = {
       name: 'English',
       autoselect: true,
       isDefault: true,
-      forced: false
-    })
-  ]
+      forced: false,
+    }),
+  ],
 };
 
 const playlist = new MasterPlaylist({
   version: 6,
   independentSegments: true,
-  variants: createVariants()
+  variants: createVariants(),
 });
 
 function createVariants() {
@@ -79,7 +79,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v9/prog_index.m3u8',
@@ -90,7 +90,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v8/prog_index.m3u8',
@@ -101,7 +101,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v7/prog_index.m3u8',
@@ -112,7 +112,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v6/prog_index.m3u8',
@@ -123,7 +123,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v4/prog_index.m3u8',
@@ -134,7 +134,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v3/prog_index.m3u8',
@@ -145,7 +145,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v2/prog_index.m3u8',
@@ -156,7 +156,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud1,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v5/prog_index.m3u8',
@@ -167,7 +167,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v9/prog_index.m3u8',
@@ -178,7 +178,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v8/prog_index.m3u8',
@@ -189,7 +189,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v7/prog_index.m3u8',
@@ -200,7 +200,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v6/prog_index.m3u8',
@@ -211,7 +211,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v4/prog_index.m3u8',
@@ -222,7 +222,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v3/prog_index.m3u8',
@@ -233,7 +233,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v2/prog_index.m3u8',
@@ -244,7 +244,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud2,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v5/prog_index.m3u8',
@@ -255,7 +255,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v9/prog_index.m3u8',
@@ -266,7 +266,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v8/prog_index.m3u8',
@@ -277,7 +277,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v7/prog_index.m3u8',
@@ -288,7 +288,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v6/prog_index.m3u8',
@@ -299,7 +299,7 @@ function createVariants() {
     frameRate: 60.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v4/prog_index.m3u8',
@@ -310,7 +310,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v3/prog_index.m3u8',
@@ -321,7 +321,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v2/prog_index.m3u8',
@@ -332,7 +332,7 @@ function createVariants() {
     frameRate: 30.0,
     audio: renditions.aud3,
     subtitles: renditions.sub1,
-    closedCaptions: renditions.cc1
+    closedCaptions: renditions.cc1,
   }));
   variants.push(new Variant({
     uri: 'v7/iframe_index.m3u8',
@@ -340,7 +340,7 @@ function createVariants() {
     bandwidth: 186522,
     averageBandwidth: 182077,
     codecs: 'avc1.64002a',
-    resolution: {width: 1920, height: 1080}
+    resolution: {width: 1920, height: 1080},
   }));
   variants.push(new Variant({
     uri: 'v6/iframe_index.m3u8',
@@ -348,7 +348,7 @@ function createVariants() {
     bandwidth: 133856,
     averageBandwidth: 129936,
     codecs: 'avc1.640020',
-    resolution: {width: 1280, height: 720}
+    resolution: {width: 1280, height: 720},
   }));
   variants.push(new Variant({
     uri: 'v5/iframe_index.m3u8',
@@ -356,7 +356,7 @@ function createVariants() {
     bandwidth: 98136,
     averageBandwidth: 94286,
     codecs: 'avc1.640020',
-    resolution: {width: 960, height: 540}
+    resolution: {width: 960, height: 540},
   }));
   variants.push(new Variant({
     uri: 'v4/iframe_index.m3u8',
@@ -364,7 +364,7 @@ function createVariants() {
     bandwidth: 76704,
     averageBandwidth: 74767,
     codecs: 'avc1.64001e',
-    resolution: {width: 768, height: 432}
+    resolution: {width: 768, height: 432},
   }));
   variants.push(new Variant({
     uri: 'v3/iframe_index.m3u8',
@@ -372,7 +372,7 @@ function createVariants() {
     bandwidth: 64078,
     averageBandwidth: 62251,
     codecs: 'avc1.64001e',
-    resolution: {width: 640, height: 360}
+    resolution: {width: 640, height: 360},
   }));
   variants.push(new Variant({
     uri: 'v2/iframe_index.m3u8',
@@ -380,7 +380,7 @@ function createVariants() {
     bandwidth: 38728,
     averageBandwidth: 37866,
     codecs: 'avc1.640015',
-    resolution: {width: 480, height: 270}
+    resolution: {width: 480, height: 270},
   }));
   return variants;
 }

--- a/test/helpers/matchers.js
+++ b/test/helpers/matchers.js
@@ -57,5 +57,5 @@ function notEqualPlaylist(t, expected, actual) {
 
 module.exports = {
   equalPlaylist,
-  notEqualPlaylist
+  notEqualPlaylist,
 };

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -91,5 +91,5 @@ module.exports = {
   bothPass,
   parseFail,
   stringifyFail,
-  stripCommentsAndEmptyLines
+  stripCommentsAndEmptyLines,
 };

--- a/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.3.2.2_EXT-X-BYTERANGE.spec.js
+++ b/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.3.2.2_EXT-X-BYTERANGE.spec.js
@@ -130,6 +130,6 @@ test('#EXT-X-BYTERANGE_05', t => {
         #EXTINF:9.9,comment
         #EXT-X-BYTERANGE:100@200
         http://example.com/2
-    `)
+    `),
   );
 });

--- a/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.3.2.7_EXT-X-DATERANGE.spec.js
+++ b/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.3.2.7_EXT-X-DATERANGE.spec.js
@@ -1,3 +1,4 @@
+const {Buffer} = require('node:buffer');
 const test = require('ava');
 const HLS = require('../../../../..');
 const utils = require('../../../../helpers/utils');

--- a/test/spec/Apple-Low-Latency/New_Media_Playlist_Tags_for_Low-Latency_HLS/03_EXT-X-PART.spec.js
+++ b/test/spec/Apple-Low-Latency/New_Media_Playlist_Tags_for_Low-Latency_HLS/03_EXT-X-PART.spec.js
@@ -204,7 +204,7 @@ test('#EXT-X-PART_05', t => {
   const {parts} = segments[1];
   t.is(parts.length, 3);
   let offset = 0;
-  const length = 20000;
+  const length = 20_000;
   for (const [index, part] of parts.entries()) {
     t.is(part.uri, 'fs241.mp4');
     t.deepEqual(part.byterange, {offset, length});

--- a/test/spec/Apple-Low-Latency/New_Media_Playlist_Tags_for_Low-Latency_HLS/04_EXT-X-PRELOAD-HINT.spec.js
+++ b/test/spec/Apple-Low-Latency/New_Media_Playlist_Tags_for_Low-Latency_HLS/04_EXT-X-PRELOAD-HINT.spec.js
@@ -42,7 +42,7 @@ test('#EXT-X-PRELOAD-HINT_02', t => {
   const {parts} = segments[1];
   t.is(parts.length, 3);
   let offset = 0;
-  const length = 20000;
+  const length = 20_000;
   for (const [index, part] of parts.entries()) {
     t.is(part.uri, 'fs241.mp4');
     t.deepEqual(part.byterange, {offset, length});

--- a/test/spec/HLSJS-LHLS/01_EXT-X-PREFETCH.spec.js
+++ b/test/spec/HLSJS-LHLS/01_EXT-X-PREFETCH.spec.js
@@ -20,7 +20,7 @@ test("#EXT-X-PREFETCH_01", t => {
 
     #EXT-X-PREFETCH:https://foo.com/bar/2.ts
     #EXT-X-PREFETCH:https://foo.com/bar/3.ts
-  `
+  `,
   );
 });
 

--- a/test/spec/HLSJS-LHLS/01_EXT-X-PREFETCH.spec.js
+++ b/test/spec/HLSJS-LHLS/01_EXT-X-PREFETCH.spec.js
@@ -1,8 +1,8 @@
-const test = require("ava");
-const utils = require("../../helpers/utils");
-const HLS = require("../../..");
+const test = require('ava');
+const utils = require('../../helpers/utils');
+const HLS = require('../../..');
 
-test("#EXT-X-PREFETCH_01", t => {
+test('#EXT-X-PREFETCH_01', t => {
   utils.bothPass(
     t,
     `
@@ -24,7 +24,7 @@ test("#EXT-X-PREFETCH_01", t => {
   );
 });
 
-test("#EXT-X-PREFETCH_02", t => {
+test('#EXT-X-PREFETCH_02', t => {
   const parsed = HLS.parse(`
     #EXTM3U
     #EXT-X-VERSION:3
@@ -44,8 +44,8 @@ test("#EXT-X-PREFETCH_02", t => {
   const {prefetchSegments} = parsed;
 
   t.is(prefetchSegments.length, 2);
-  t.is(prefetchSegments[0].uri, "https://foo.com/bar/2.ts");
-  t.is(prefetchSegments[1].uri, "https://foo.com/bar/3.ts");
+  t.is(prefetchSegments[0].uri, 'https://foo.com/bar/2.ts');
+  t.is(prefetchSegments[1].uri, 'https://foo.com/bar/3.ts');
 
   const stringified = HLS.stringify(parsed);
 
@@ -55,7 +55,7 @@ test("#EXT-X-PREFETCH_02", t => {
 
 // If delivering a low-latency stream, the server must deliver at least one
 // prefetch segment, but no more than two.
-test("#EXT-X-PREFETCH_03", t => {
+test('#EXT-X-PREFETCH_03', t => {
   const parsed = HLS.parse(`
     #EXTM3U
     #EXT-X-VERSION:3
@@ -85,7 +85,7 @@ test("#EXT-X-PREFETCH_03", t => {
 });
 
 // These segments must appear after all complete segments.
-test("#EXT-X-PREFETCH_04", t => {
+test('#EXT-X-PREFETCH_04', t => {
   try {
     HLS.parse(`
       #EXTM3U
@@ -116,7 +116,7 @@ test("#EXT-X-PREFETCH_04", t => {
 // EXT-X-DISCONTINUITY-SEQUENCE tag (or zero if none) plus the number of
 // EXT-X-DISCONTINUITY and EXT-X-PREFETCH-DISCONTINUITY tags in the Playlist
 // preceding the URI line of the segment.
-test("#EXT-X-PREFETCH_05", t => {
+test('#EXT-X-PREFETCH_05', t => {
   const parsed = HLS.parse(`
     #EXTM3U
     #EXT-X-VERSION:3
@@ -146,7 +146,7 @@ test("#EXT-X-PREFETCH_05", t => {
 // The Media Sequence Number of every other prefetch segment is equal to the
 // Media Sequence Number of the complete segment or prefetch segment that
 // precedes it plus one.
-test("#EXT-X-PREFETCH_06", t => {
+test('#EXT-X-PREFETCH_06', t => {
   let parsed;
   parsed = HLS.parse(`
     #EXTM3U
@@ -175,7 +175,7 @@ test("#EXT-X-PREFETCH_06", t => {
 // A prefetch segment must not be advertised with an EXTINF tag. The duration of
 // a prefetch segment must be equal to or less than what is specified by the
 // EXT-X-TARGETDURATION tag.
-test("#EXT-X-PREFETCH_07", t => {
+test('#EXT-X-PREFETCH_07', t => {
   try {
     HLS.parse(`
       #EXTM3U
@@ -197,7 +197,7 @@ test("#EXT-X-PREFETCH_07", t => {
 // To insert a discontinuity just for prefetch segments, the server must insert
 // the EXT-X-PREFETCH-DISCONTINUITY tag before the newest EXT-X-PREFETCH tag of
 // the new discontinuous range.
-test("#EXT-X-PREFETCH_08", t => {
+test('#EXT-X-PREFETCH_08', t => {
   try {
     HLS.parse(`
       #EXTM3U
@@ -215,7 +215,7 @@ test("#EXT-X-PREFETCH_08", t => {
 });
 
 // Prefetch segments must not be advertised with an EXT-X-MAP tag.
-test("#EXT-X-PREFETCH_09", t => {
+test('#EXT-X-PREFETCH_09', t => {
   try {
     HLS.parse(`
       #EXTM3U
@@ -234,7 +234,7 @@ test("#EXT-X-PREFETCH_09", t => {
 
 // Prefetch segments may be advertised with an EXT-X-KEY tag. The key itself
 // must be complete; the server must not expect the client to progressively stream keys.
-test("#EXT-X-PREFETCH_10", t => {
+test('#EXT-X-PREFETCH_10', t => {
   const parsed = HLS.parse(`
     #EXTM3U
     #EXT-X-VERSION:3

--- a/test/spec/HLSJS-LHLS/02_EXT-X-PREFETCH-DISCONTINUITY.spec.js
+++ b/test/spec/HLSJS-LHLS/02_EXT-X-PREFETCH-DISCONTINUITY.spec.js
@@ -1,8 +1,8 @@
-const test = require("ava");
-const utils = require("../../helpers/utils");
-const HLS = require("../../..");
+const test = require('ava');
+const utils = require('../../helpers/utils');
+const HLS = require('../../..');
 
-test("#EXT-X-PREFETCH-DISCONTINUITY_01", t => {
+test('#EXT-X-PREFETCH-DISCONTINUITY_01', t => {
   const text = `
     #EXTM3U
     #EXT-X-VERSION:3
@@ -27,7 +27,7 @@ test("#EXT-X-PREFETCH-DISCONTINUITY_01", t => {
   t.falsy(prefetchSegments[1].discontinuity);
 });
 
-test("#EXT-X-PREFETCH-DISCONTINUITY_02", t => {
+test('#EXT-X-PREFETCH-DISCONTINUITY_02', t => {
   const text = `
     #EXTM3U
     #EXT-X-VERSION:3

--- a/test/spec/misc/scte-35.spec.js
+++ b/test/spec/misc/scte-35.spec.js
@@ -11,7 +11,7 @@ test("#EXT-X-CUE-IN_01", t => {
 
   const playlist = new MediaPlaylist({
     targetDuration: 10,
-    segments
+    segments,
   });
 
   // For live media playlist, unclosed CUE-OUT is allowed.
@@ -41,7 +41,7 @@ test("#EXT-X-CUE-IN_02", t => {
   const playlist = new MediaPlaylist({
     playlistType: 'VOD',
     targetDuration: 10,
-    segments
+    segments,
   });
 
   // For VOD media playlist, unclosed CUE-OUT is not allowed.
@@ -75,7 +75,7 @@ test("#EXT-X-CUE-IN_03", t => {
   const playlist = new MediaPlaylist({
     playlistType: 'EVENT',
     targetDuration: 10,
-    segments
+    segments,
   });
 
   // For live media playlist, unclosed CUE-OUT is allowed.
@@ -114,7 +114,7 @@ test("#EXT-X-CUE-IN_04", t => {
   const playlist = new MediaPlaylist({
     playlistType: 'VOD',
     targetDuration: 10,
-    segments
+    segments,
   });
 
   // For VOD media playlist, unclosed CUE-OUT is not allowed.

--- a/test/spec/misc/scte-35.spec.js
+++ b/test/spec/misc/scte-35.spec.js
@@ -1,8 +1,8 @@
-const test = require("ava");
-const utils = require("../../helpers/utils");
-const HLS = require("../../..");
+const test = require('ava');
+const utils = require('../../helpers/utils');
+const HLS = require('../../..');
 
-test("#EXT-X-CUE-IN_01", t => {
+test('#EXT-X-CUE-IN_01', t => {
   const {MediaPlaylist, Segment} = HLS.types;
 
   const segments = [...Array.from({length: 3})].map((_, i) => new Segment({uri: `https://example.com/${i}.ts`, duration: 10}));
@@ -31,7 +31,7 @@ test("#EXT-X-CUE-IN_01", t => {
   t.is(HLS.stringify(playlist), utils.stripCommentsAndEmptyLines(expected));
 });
 
-test("#EXT-X-CUE-IN_02", t => {
+test('#EXT-X-CUE-IN_02', t => {
   const {MediaPlaylist, Segment} = HLS.types;
 
   const segments = [...Array.from({length: 3})].map((_, i) => new Segment({uri: `https://example.com/${i}.ts`, duration: 10}));
@@ -64,7 +64,7 @@ test("#EXT-X-CUE-IN_02", t => {
   t.is(HLS.stringify(playlist), utils.stripCommentsAndEmptyLines(expected));
 });
 
-test("#EXT-X-CUE-IN_03", t => {
+test('#EXT-X-CUE-IN_03', t => {
   const {MediaPlaylist, Segment} = HLS.types;
 
   const segments = [...Array.from({length: 6})].map((_, i) => new Segment({uri: `https://example.com/${i}.ts`, duration: 10}));
@@ -103,7 +103,7 @@ test("#EXT-X-CUE-IN_03", t => {
   t.is(HLS.stringify(playlist), utils.stripCommentsAndEmptyLines(expected));
 });
 
-test("#EXT-X-CUE-IN_04", t => {
+test('#EXT-X-CUE-IN_04', t => {
   const {MediaPlaylist, Segment} = HLS.types;
 
   const segments = [...Array.from({length: 6})].map((_, i) => new Segment({uri: `https://example.com/${i}.ts`, duration: 10}));

--- a/test/spec/utils.spec.js
+++ b/test/spec/utils.spec.js
@@ -1,3 +1,4 @@
+const {Buffer} = require('node:buffer');
 const test = require('ava');
 const rewire = require('rewire');
 const utils = require('../../utils');

--- a/test/spec/utils.spec.js
+++ b/test/spec/utils.spec.js
@@ -77,18 +77,18 @@ test('utils.byteSequenceToHex', t => {
 test('utils.tryCatch', t => {
   let result = utils.tryCatch(
     () => 1,
-    () => 0
+    () => 0,
   );
   t.is(result, 1);
   result = utils.tryCatch(
     () => JSON.parse('{{'),
-    () => 0
+    () => 0,
   );
   t.is(result, 0);
   t.throws(() => {
     utils.tryCatch(
       () => JSON.parse('{{'),
-      () => JSON.parse('}}')
+      () => JSON.parse('}}'),
     );
   });
 });
@@ -170,8 +170,8 @@ test('utils.THROW.silent', t => {
   utils.__set__({
     console: {
       error: errorHandler,
-      log: console.log
-    }
+      log: console.log,
+    },
   });
   const message = 'Error Message';
   utils.setOptions({strictMode: false});

--- a/test/spec/utils.spec.js
+++ b/test/spec/utils.spec.js
@@ -76,31 +76,19 @@ test('utils.byteSequenceToHex', t => {
 
 test('utils.tryCatch', t => {
   let result = utils.tryCatch(
-    () => {
-      return 1;
-    },
-    () => {
-      return 0;
-    }
+    () => 1,
+    () => 0
   );
   t.is(result, 1);
   result = utils.tryCatch(
-    () => {
-      return JSON.parse('{{');
-    },
-    () => {
-      return 0;
-    }
+    () => JSON.parse('{{'),
+    () => 0
   );
   t.is(result, 0);
   t.throws(() => {
     utils.tryCatch(
-      () => {
-        return JSON.parse('{{');
-      },
-      () => {
-        return JSON.parse('}}');
-      }
+      () => JSON.parse('{{'),
+      () => JSON.parse('}}')
     );
   });
 });

--- a/types.js
+++ b/types.js
@@ -13,7 +13,7 @@ class Rendition {
     forced,
     instreamId, // required if type=CLOSED-CAPTIONS
     characteristics,
-    channels
+    channels,
   }) {
     utils.PARAMCHECK(type, groupId, name);
     utils.CONDITIONALASSERT([type === 'SUBTITLES', uri], [type === 'CLOSED-CAPTIONS', instreamId], [type === 'CLOSED-CAPTIONS', !uri], [forced, type === 'SUBTITLES']);
@@ -50,7 +50,7 @@ class Variant {
     video = [],
     subtitles = [],
     closedCaptions = [],
-    currentRenditions = {audio: 0, video: 0, subtitles: 0, closedCaptions: 0}
+    currentRenditions = {audio: 0, video: 0, subtitles: 0, closedCaptions: 0},
   }) {
     // utils.PARAMCHECK(uri, bandwidth, codecs);
     utils.PARAMCHECK(uri, bandwidth); // the spec states that CODECS is required but not true in the real world
@@ -79,7 +79,7 @@ class SessionData {
     id, // required
     value,
     uri,
-    language
+    language,
   }) {
     utils.PARAMCHECK(id, value || uri);
     utils.ASSERT('SessionData cannot have both value and uri, shoud be either.', !(value && uri));
@@ -96,7 +96,7 @@ class Key {
     uri, // required unless method=NONE
     iv,
     format,
-    formatVersion
+    formatVersion,
   }) {
     utils.PARAMCHECK(method);
     utils.CONDITIONALPARAMCHECK([method !== 'NONE', uri]);
@@ -114,7 +114,7 @@ class MediaInitializationSection {
     hint = false,
     uri, // required
     mimeType,
-    byterange
+    byterange,
   }) {
     utils.PARAMCHECK(uri);
     this.hint = hint;
@@ -133,7 +133,7 @@ class DateRange {
     duration,
     plannedDuration,
     endOnNext,
-    attributes = {}
+    attributes = {},
   }) {
     utils.PARAMCHECK(id);
     utils.CONDITIONALPARAMCHECK([endOnNext === true, classId]);
@@ -154,7 +154,7 @@ class SpliceInfo {
     type, // required
     duration, // required if the type is 'OUT'
     tagName, // required if the type is 'RAW'
-    value
+    value,
   }) {
     utils.PARAMCHECK(type);
     utils.CONDITIONALPARAMCHECK([type === 'OUT', duration]);
@@ -180,7 +180,7 @@ class Playlist extends Data {
     version,
     independentSegments = false,
     start,
-    source
+    source,
   }) {
     super('playlist');
     utils.PARAMCHECK(isMasterPlaylist);
@@ -201,7 +201,7 @@ class MasterPlaylist extends Playlist {
       variants = [],
       currentVariant,
       sessionDataList = [],
-      sessionKeyList = []
+      sessionKeyList = [],
     } = params;
     this.variants = variants;
     this.currentVariant = currentVariant;
@@ -227,7 +227,7 @@ class MediaPlaylist extends Playlist {
       partTargetDuration,
       renditionReports = [],
       skip = 0,
-      hash
+      hash,
     } = params;
     this.targetDuration = targetDuration;
     this.mediaSequenceBase = mediaSequenceBase;
@@ -261,7 +261,7 @@ class Segment extends Data {
     programDateTime,
     dateRange,
     markers = [],
-    parts = []
+    parts = [],
   }) {
     super('segment');
     // utils.PARAMCHECK(uri, mediaSequenceNumber, discontinuitySequence);
@@ -290,7 +290,7 @@ class PartialSegment extends Data {
     duration,
     independent,
     byterange,
-    gap
+    gap,
   }) {
     super('part');
     utils.PARAMCHECK(uri);
@@ -310,7 +310,7 @@ class PrefetchSegment extends Data {
     discontinuity,
     mediaSequenceNumber = 0,
     discontinuitySequence = 0,
-    key
+    key,
   }) {
     super('prefetch');
     utils.PARAMCHECK(uri);
@@ -326,7 +326,7 @@ class RenditionReport {
   constructor({
     uri, // required
     lastMSN,
-    lastPart
+    lastPart,
   }) {
     utils.PARAMCHECK(uri);
     this.uri = uri;
@@ -349,5 +349,5 @@ module.exports = {
   Segment,
   PartialSegment,
   PrefetchSegment,
-  RenditionReport
+  RenditionReport,
 };

--- a/utils.js
+++ b/utils.js
@@ -213,5 +213,5 @@ module.exports = {
   formatDate,
   hasOwnProp,
   setOptions,
-  getOptions
+  getOptions,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = (_, argv) => ({
     path: path.resolve(__dirname, 'dist'),
     filename: `hls-parser${argv.mode === 'production' ? '.min' : ''}.js`,
     library: 'HLS',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
   },
   module: {
     rules: [
@@ -16,16 +16,16 @@ module.exports = (_, argv) => ({
         exclude: /node_modules/,
         loader: 'babel-loader',
         options: {
-          presets: ['@babel/preset-env']
-        }
-      }
-    ]
+          presets: ['@babel/preset-env'],
+        },
+      },
+    ],
   },
   devtool: argv.mode === 'production' ? 'source-map' : false,
   optimization: {
     minimize: argv.mode === 'production',
     minimizer: [
-      new TerserPlugin()
-    ]
-  }
+      new TerserPlugin(),
+    ],
+  },
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,33 +1,31 @@
 const path = require('node:path');
 const TerserPlugin = require('terser-webpack-plugin');
 
-module.exports = (_, argv) => {
-  return {
-    entry: './index.js',
-    output: {
-      path: path.resolve(__dirname, 'dist'),
-      filename: `hls-parser${argv.mode === 'production' ? '.min' : ''}.js`,
-      library: 'HLS',
-      libraryTarget: 'umd'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env']
-          }
+module.exports = (_, argv) => ({
+  entry: './index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: `hls-parser${argv.mode === 'production' ? '.min' : ''}.js`,
+    library: 'HLS',
+    libraryTarget: 'umd'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        options: {
+          presets: ['@babel/preset-env']
         }
-      ]
-    },
-    devtool: argv.mode === 'production' ? 'source-map' : false,
-    optimization: {
-      minimize: argv.mode === 'production',
-      minimizer: [
-        new TerserPlugin()
-      ]
-    }
-  };
-};
+      }
+    ]
+  },
+  devtool: argv.mode === 'production' ? 'source-map' : false,
+  optimization: {
+    minimize: argv.mode === 'production',
+    minimizer: [
+      new TerserPlugin()
+    ]
+  }
+});


### PR DESCRIPTION
This reduces the numbers of linting warnings by running `xo --fix`.

The reductions were split into individual commits for each rule:
* c72d3bd Remove the linting errors for the `quote` rule
* b28c677 Remove the linting errors for the `unicorn/numeric-separators-style` rule
* 78867ab Reduce the linting errors for the `n/prefer-global/buffer` rule
* 53ac6b8 Remove the linting errors for the `operator-linebreak` rule
* 478d745 Remove the linting errors for the `node/prefer-global/buffer` rule
* aac4d4c Remove the linting errors for the `comma-dangle` rule
* dacd6ef Remove the linting errors for the `ava/no-ignored-test-files` rule
* a9cf33c Remove the linting errors for the `arrow-body-style` rule

The intent is that only a subset of the changes can be applied if needed.
