### PR TITLE
PROGRAM-ID Attribute added to parse and stringify methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.10.6",
   "description": "A simple library to read/write HLS playlists",
   "main": "index.js",
-  "type": "module",
   "browser": "dist/hls-parser.min.js",
   "scripts": {
     "lint": "xo",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.10.6",
   "description": "A simple library to read/write HLS playlists",
   "main": "index.js",
+  "type": "module",
   "browser": "dist/hls-parser.min.js",
   "scripts": {
     "lint": "xo",

--- a/parse.ts
+++ b/parse.ts
@@ -330,7 +330,8 @@ function parseVariant(lines, variantAttrs, uri, iFrameOnly, params) {
     hdcpLevel: variantAttrs['HDCP-LEVEL'],
     allowedCpc: variantAttrs['ALLOWED-CPC'],
     videoRange: variantAttrs['VIDEO-RANGE'],
-    stableVariantId: variantAttrs['STABLE-VARIANT-ID']
+    stableVariantId: variantAttrs['STABLE-VARIANT-ID'],
+    programId: variantAttrs['PROGRAM-ID']
   });
   for (const line of lines) {
     if (line.name === 'EXT-X-MEDIA') {

--- a/stringify.ts
+++ b/stringify.ts
@@ -173,6 +173,9 @@ function buildVariant(lines, variant) {
   if (variant.stableVariantId) {
     attrs.push(`STABLE-VARIANT-ID="${variant.stableVariantId}"`);
   }
+  if (variant.programId) {
+    attrs.push(`PROGRAM-ID=${variant.programId}`);
+  }
   lines.push(`${name}:${attrs.join(',')}`);
   if (!variant.isIFrameOnly) {
     lines.push(`${variant.uri}`);

--- a/types.ts
+++ b/types.ts
@@ -58,6 +58,7 @@ class Variant {
   allowedCpc: any;
   videoRange: any;
   stableVariantId: any;
+  programId: any;
   audio: Rendition[];
   video: Rendition[];
   subtitles: Rendition[];
@@ -77,6 +78,7 @@ class Variant {
     allowedCpc,
     videoRange,
     stableVariantId,
+    programId,
     audio = [],
     video = [],
     subtitles = [],
@@ -97,6 +99,7 @@ class Variant {
     this.allowedCpc = allowedCpc;
     this.videoRange = videoRange;
     this.stableVariantId = stableVariantId;
+    this.programId = programId;
     this.audio = audio;
     this.video = video;
     this.subtitles = subtitles;


### PR DESCRIPTION
It is also being parsed to number as it is always an integer value, check [HLS documentation](https://datatracker.ietf.org/doc/html/draft-pantos-http-live-streaming-07#section-3.3.10)