### PR TITLE
Generate type declarations automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ build/Release
 
 # Typescript intermediate files
 tsconfig.tsbuildinfo
+*.d.ts
 *.js
 !test/**/*.js
 

--- a/.npmignore
+++ b/.npmignore
@@ -30,6 +30,10 @@ build/Release
 node_modules
 jspm_packages
 
+# Editors
+.idea/
+.vscode/
+
 # Optional npm cache directory
 .npm
 
@@ -37,8 +41,13 @@ jspm_packages
 .node_repl_history
 
 test
+.github/
 .node-version
 .travis.yml
 .npmignore
+data-structure.png
+tsconfig.tsbuildinfo
 webpack.config.js
 LICENSE
+*.ts
+!*.d.ts

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "0.10.8",
   "description": "A simple library to read/write HLS playlists",
   "main": "index.js",
+  "types": "index.d.ts",
   "browser": "dist/hls-parser.min.js",
   "scripts": {
     "lint": "xo",
     "type-check": "tsc --noEmit",
     "audit": "npm audit --audit-level high",
-    "build": "rm -fR ./dist; webpack --mode development ; webpack --mode production",
+    "build": "rm -fR ./dist; tsc ; webpack --mode development ; webpack --mode production",
     "test": "npm run lint && npm run build && npm run audit && ava --verbose"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
+    "declaration": true,
     "noImplicitAny": false
   },
   "exclude": [


### PR DESCRIPTION
This lets the Typescript compiler also generates the types' declarations.

This permits to avoid creating local type declarations or using a separate type package ([@types/hls-parser](https://www.npmjs.com/package/@types/hls-parser)) when using the `hls-parser` in a Typescript project. The type definitions in [@types/hls-parser](https://www.npmjs.com/package/@types/hls-parser) are not up-to-date for example.