### PR TITLE
Add support for EXT-X-GAP

### DIFF
--- a/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.4.4.7_EXT-X-GAP.spec.js
+++ b/test/spec/4_Playlists/4.3_Playlist-Tags/4.3.2_Media-Segment-Tags/4.4.4.7_EXT-X-GAP.spec.js
@@ -1,0 +1,40 @@
+const test = require("ava");
+const utils = require("../../../../helpers/utils");
+
+// https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.7
+
+test('#EXT-X-TAG_01', t => {
+  utils.parseFail(t, `
+    #EXTM3U
+    #EXT-X-VERSION:8
+    #EXT-X-GAP
+    1.ts
+  `);
+  utils.parsePass(t, `
+    #EXTM3U
+    #EXT-X-VERSION:8
+    #EXT-X-TARGETDURATION:5
+    #EXT-X-GAP
+    #EXTINF:4,
+    1.ts
+  `);
+});
+
+test('#EXT-X-TAG_02', t => {
+  utils.parseFail(t, `
+    #EXTM3U
+    #EXT-X-VERSION:8
+    #EXT-X-TARGETDURATION:5
+    #EXT-X-GAP
+    #EXT-X-PART:DURATION=2,URI="1.ts"
+    #EXT-X-ENDLIST
+  `);
+  utils.parsePass(t, `
+    #EXTM3U
+    #EXT-X-VERSION:8
+    #EXT-X-TARGETDURATION:5
+    #EXT-X-GAP
+    #EXT-X-PART:DURATION=2,URI="1.ts",GAP=YES
+    #EXT-X-ENDLIST
+  `);
+});

--- a/test/spec/7_Protocol-version-compatibility/7_EXT-X-VERSION.spec.js
+++ b/test/spec/7_Protocol-version-compatibility/7_EXT-X-VERSION.spec.js
@@ -274,3 +274,16 @@ test('#EXT-X-VERSION_11', t => {
     http://example.com
   `);
 });
+
+// A Media Playlist MUST indicate a EXT-X-VERSION of 8 or higher if it
+// contains:
+// - the "EXT-X-GAP" tag.
+test('#EXT-X-VERSION_12', t => {
+  utils.parseFail(t, `
+    #EXTM3U
+    #EXT-X-VERSION:1
+    #EXTINF:5
+    #EXT-X-GAP
+    http://example.com
+  `);
+});

--- a/types.ts
+++ b/types.ts
@@ -367,6 +367,7 @@ class Segment extends Data {
   dateRange: DateRange;
   markers: SpliceInfo[];
   parts: PartialSegment[];
+  gap?: boolean;
 
   constructor({
     uri,
@@ -383,7 +384,8 @@ class Segment extends Data {
     programDateTime,
     dateRange,
     markers = [],
-    parts = []
+    parts = [],
+    gap
   }: any) {
     super('segment');
     // utils.PARAMCHECK(uri, mediaSequenceNumber, discontinuitySequence);
@@ -402,6 +404,7 @@ class Segment extends Data {
     this.dateRange = dateRange;
     this.markers = markers;
     this.parts = parts;
+    this.gap = gap;
   }
 }
 


### PR DESCRIPTION
This adds support for the `EXT-X-GAP` defined in:
- https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.7

According to the Apple documentation [About the EXT-X-VERSION tag](https://developer.apple.com/documentation/http-live-streaming/about-the-ext-x-version-tag), the tag `EXT-X-GAP` requires a `EXT-X-VERSION` of 8:
- https://developer.apple.com/documentation/http-live-streaming/about-the-ext-x-version-tag#High-level-features