### PR TITLE
feat: add type discriminator for MasterPlaylist and MediaPlaylist

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -276,6 +276,7 @@ class Playlist extends Data {
 }
 
 class MasterPlaylist extends Playlist {
+  declare isMasterPlaylist: true;
   variants: Variant[];
   currentVariant?: number;
   sessionDataList: SessionData[];
@@ -304,6 +305,7 @@ type LowLatencyCompatibility = {
 };
 
 class MediaPlaylist extends Playlist {
+  declare isMasterPlaylist: false;
   targetDuration: number;
   mediaSequenceBase?: number;
   discontinuitySequenceBase?: number;


### PR DESCRIPTION
## Summary

This PR adds TypeScript discriminator properties to `MasterPlaylist` and `MediaPlaylist` classes to enable proper type narrowing when checking the `isMasterPlaylist` boolean property.

## Changes

- Added `declare isMasterPlaylist: true` to `MasterPlaylist` class
- Added `declare isMasterPlaylist: false` to `MediaPlaylist` class

## Benefits

### Enhanced Type Safety
With these discriminator properties, TypeScript can now properly narrow types when using the `isMasterPlaylist` property:

```typescript
// Before: playlist is still Playlist type after the check
if (playlist.isMasterPlaylist) {
  // TypeScript doesn't know this is a MasterPlaylist
  playlist.variants; // Type error - variants doesn't exist on Playlist
}

// After: TypeScript automatically narrows the type
if (playlist.isMasterPlaylist) {
  // TypeScript knows this is a MasterPlaylist
  playlist.variants; // ✅ No type error - variants exists on MasterPlaylist
} else {
  // TypeScript knows this is a MediaPlaylist
  playlist.segments; // ✅ No type error - segments exists on MediaPlaylist
}
```

### No Runtime Impact
The `declare` keyword ensures these properties exist only at compile time for type checking - they don't affect runtime behavior or bundle size.

### Backward Compatibility
All existing code continues to work unchanged since the base `Playlist` class already contains the `isMasterPlaylist: boolean` property.

## Implementation Details

This follows the TypeScript discriminated union pattern where:
- The discriminator property (`isMasterPlaylist`) exists on the base type
- Each subclass declares the specific literal value for that property
- TypeScript uses this information to narrow types automatically

🤖 Generated with [Claude Code](https://claude.ai/code)